### PR TITLE
feat(search): recursive filename find via Ctrl+P

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.0] - 2026-03-23
+
+### Added
+- Recursive filename find (`Ctrl+P`): live search across all files under the current directory, updating results on every keystroke
+- New `src/find.rs` module: `run_find()` prefers `fd` when available and falls back to a built-in directory walker; walker skips hidden dirs, `target/`, and `node_modules/`
+- Results capped at 500 entries with a `[truncated]` notice in the pane title
+- Results sorted by relevance: exact filename/stem match → prefix → substring
+- `j`/`k` navigate results; `l`/`Enter`/`→` jump to the selected file (navigates to its parent directory, selects the file, exits find mode, and pushes a history entry); `Esc` or `Ctrl+P` again cancels without side effects
+- `Ctrl+P` added to the help overlay (`?`) under the Search section
+- 7 unit tests covering output parsing, empty-query short-circuit, truncation, relevance sorting, walker finds, and hidden-directory skip
+
 ## [0.11.0] - 2026-03-23
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trek"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 rust-version = "1.80"
 description = "A terminal file manager with mouse-resizable panes"

--- a/src/app.rs
+++ b/src/app.rs
@@ -190,6 +190,20 @@ pub struct App {
     /// Current sort direction.
     pub sort_order: SortOrder,
 
+    // --- Recursive find (Ctrl+P) ---
+    /// True while the recursive filename find overlay is open.
+    pub find_mode: bool,
+    /// Query string typed by the user.
+    pub find_query: String,
+    /// Results from the last find run.
+    pub find_results: Vec<crate::find::FindResult>,
+    /// Index of the currently highlighted result.
+    pub find_selected: usize,
+    /// Error message shown when the search fails.
+    pub find_error: Option<String>,
+    /// True when results were capped at MAX_FIND_RESULTS.
+    pub find_truncated: bool,
+
     // --- Directory jump history ---
     /// Chronological list of visited locations; `history[history_pos]` is current.
     history: Vec<HistoryEntry>,
@@ -264,6 +278,12 @@ impl App {
             rename_error: None,
             sort_mode: SortMode::default(),
             sort_order: SortOrder::default(),
+            find_mode: false,
+            find_query: String::new(),
+            find_results: Vec::new(),
+            find_selected: 0,
+            find_error: None,
+            find_truncated: false,
             history: vec![HistoryEntry {
                 dir: cwd.clone(),
                 selected: 0,
@@ -1483,6 +1503,106 @@ impl App {
                 self.preview_scroll = (target_line as usize).saturating_sub(1);
             }
         }
+    }
+
+    // --- Recursive find (Ctrl+P) ---
+
+    /// Enter recursive filename find mode.
+    pub fn start_find(&mut self) {
+        self.find_mode = true;
+        self.find_query.clear();
+        self.find_results.clear();
+        self.find_selected = 0;
+        self.find_error = None;
+        self.find_truncated = false;
+    }
+
+    /// Exit find mode without side effects.
+    pub fn cancel_find(&mut self) {
+        self.find_mode = false;
+        self.find_query.clear();
+        self.find_results.clear();
+        self.find_selected = 0;
+        self.find_error = None;
+        self.find_truncated = false;
+    }
+
+    /// Append a character to the find query and re-run the search.
+    pub fn find_push_char(&mut self, c: char) {
+        self.find_query.push(c);
+        self.find_selected = 0;
+        self.exec_find();
+    }
+
+    /// Remove the last character from the find query and re-run the search.
+    pub fn find_pop_char(&mut self) {
+        self.find_query.pop();
+        self.find_selected = 0;
+        self.exec_find();
+    }
+
+    /// Move the find selection down by one result.
+    pub fn find_move_down(&mut self) {
+        if !self.find_results.is_empty() && self.find_selected + 1 < self.find_results.len() {
+            self.find_selected += 1;
+        }
+    }
+
+    /// Move the find selection up by one result.
+    pub fn find_move_up(&mut self) {
+        self.find_selected = self.find_selected.saturating_sub(1);
+    }
+
+    /// Execute the find query against the current working directory.
+    fn exec_find(&mut self) {
+        match crate::find::run_find(&self.find_query, &self.cwd) {
+            Ok(results) => {
+                self.find_truncated = results.len() >= crate::find::MAX_FIND_RESULTS;
+                self.find_results = results;
+                self.find_error = None;
+            }
+            Err(e) => {
+                self.find_results.clear();
+                self.find_error = Some(e);
+                self.find_truncated = false;
+            }
+        }
+    }
+
+    /// Navigate to the currently selected find result: change `cwd` to the
+    /// file's parent directory, select the file, exit find mode, and push a
+    /// history entry.
+    pub fn jump_to_find_result(&mut self) {
+        let Some(result) = self.find_results.get(self.find_selected).cloned() else {
+            return;
+        };
+
+        let file_path = result.absolute;
+        let Some(parent) = file_path.parent() else {
+            return;
+        };
+
+        if parent != self.cwd {
+            let new_dir = parent.to_path_buf();
+            self.push_history(new_dir.clone());
+            self.cwd = new_dir;
+            self.selected = 0;
+            self.current_scroll = 0;
+            self.load_dir();
+        }
+
+        // Select the file in the entry list.
+        if let Some(name) = file_path
+            .file_name()
+            .map(|n| n.to_string_lossy().into_owned())
+        {
+            if let Some(idx) = self.entries.iter().position(|e| e.name == name) {
+                self.selected = idx;
+                self.load_preview();
+            }
+        }
+
+        self.cancel_find();
     }
 
     // --- Clipboard (OSC 52) ---

--- a/src/find.rs
+++ b/src/find.rs
@@ -1,0 +1,286 @@
+//! Recursive filename search (Ctrl+P).
+//!
+//! Prefers `fd` when it is available on PATH; falls back to a built-in
+//! directory walker when `fd` is not installed.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Maximum number of find results returned to the UI.
+pub const MAX_FIND_RESULTS: usize = 500;
+
+/// One hit from a recursive filename search.
+#[derive(Debug, Clone)]
+pub struct FindResult {
+    /// Path relative to the search root (used for display).
+    pub relative: PathBuf,
+    /// Absolute path (used for navigation).
+    pub absolute: PathBuf,
+}
+
+/// Run a recursive case-insensitive filename search under `root` for files
+/// whose name contains `query`.  Returns up to [`MAX_FIND_RESULTS`] results
+/// sorted by relevance: exact name match first, then prefix, then substring.
+///
+/// Returns an empty `Vec` immediately when `query` is empty.
+pub fn run_find(query: &str, root: &Path) -> Result<Vec<FindResult>, String> {
+    if query.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let mut results = if let Some(r) = run_fd(query, root) {
+        r
+    } else {
+        run_walker(query, root)
+    };
+
+    sort_results(query, &mut results);
+    results.truncate(MAX_FIND_RESULTS);
+    Ok(results)
+}
+
+// ── fd integration ────────────────────────────────────────────────────────────
+
+/// Try to run `fd` for a fast search. Returns `None` when `fd` is not found.
+fn run_fd(query: &str, root: &Path) -> Option<Vec<FindResult>> {
+    let output = Command::new("fd")
+        .args([
+            "--type",
+            "f",
+            "--max-results",
+            "500",
+            "--ignore-case",
+            query,
+        ])
+        .current_dir(root)
+        .output()
+        .ok()?;
+
+    // fd exits non-zero when nothing matches; that is still a valid result.
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    if stdout.is_empty() && !output.status.success() {
+        return None;
+    }
+
+    Some(parse_fd_output(&stdout, root))
+}
+
+/// Convert newline-delimited `fd` output into [`FindResult`] structs.
+///
+/// Each line is treated as a path relative to `root`.
+pub fn parse_fd_output(output: &str, root: &Path) -> Vec<FindResult> {
+    output
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .take(MAX_FIND_RESULTS)
+        .map(|line| {
+            let relative = PathBuf::from(line.trim());
+            let absolute = root.join(&relative);
+            FindResult { relative, absolute }
+        })
+        .collect()
+}
+
+// ── built-in walker ───────────────────────────────────────────────────────────
+
+/// Built-in recursive walker used as a fallback when `fd` is unavailable.
+fn run_walker(query: &str, root: &Path) -> Vec<FindResult> {
+    let mut results = Vec::new();
+    walk_dir(root, root, query, &mut results);
+    results
+}
+
+fn walk_dir(root: &Path, dir: &Path, query: &str, results: &mut Vec<FindResult>) {
+    if results.len() >= MAX_FIND_RESULTS {
+        return;
+    }
+
+    let Ok(read) = std::fs::read_dir(dir) else {
+        return;
+    };
+
+    for entry in read.flatten() {
+        if results.len() >= MAX_FIND_RESULTS {
+            return;
+        }
+
+        let path = entry.path();
+        let raw_name = entry.file_name();
+        let name_str = raw_name.to_string_lossy();
+
+        // Skip hidden entries and well-known large/irrelevant directories.
+        if name_str.starts_with('.') || name_str == "target" || name_str == "node_modules" {
+            continue;
+        }
+
+        if path.is_dir() {
+            walk_dir(root, &path, query, results);
+        } else {
+            let query_lower = query.to_lowercase();
+            let name_lower = name_str.to_lowercase();
+            if name_lower.contains(&query_lower) {
+                if let Ok(relative) = path.strip_prefix(root) {
+                    results.push(FindResult {
+                        relative: relative.to_path_buf(),
+                        absolute: path,
+                    });
+                }
+            }
+        }
+    }
+}
+
+// ── sorting ───────────────────────────────────────────────────────────────────
+
+/// Sort results by relevance.
+///
+/// Priority (checked against both full filename and bare stem):
+///   0 — exact match on full filename or stem
+///   1 — prefix match on full filename or stem
+///   2 — substring match (fallback)
+fn sort_results(query: &str, results: &mut [FindResult]) {
+    let q = query.to_lowercase();
+    results.sort_by_key(|r| {
+        let name = r
+            .relative
+            .file_name()
+            .map(|n| n.to_string_lossy().to_lowercase())
+            .unwrap_or_default();
+        let stem = r
+            .relative
+            .file_stem()
+            .map(|n| n.to_string_lossy().to_lowercase())
+            .unwrap_or_default();
+        if name == q || stem == q {
+            0u8
+        } else if name.starts_with(&q) || stem.starts_with(&q) {
+            1
+        } else {
+            2
+        }
+    });
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn make_result(relative: &str, root: &Path) -> FindResult {
+        let rel = PathBuf::from(relative);
+        let abs = root.join(&rel);
+        FindResult {
+            relative: rel,
+            absolute: abs,
+        }
+    }
+
+    /// Given: `fd` output with 3 relative paths
+    /// When: parse_fd_output is called
+    /// Then: 3 FindResult entries are returned with matching relative paths
+    #[test]
+    fn parse_fd_output_three_lines() {
+        let root = Path::new("/tmp");
+        let output = "src/main.rs\nsrc/lib.rs\ntests/foo.rs\n";
+        let results = parse_fd_output(output, root);
+        assert_eq!(results.len(), 3);
+        assert_eq!(results[0].relative, PathBuf::from("src/main.rs"));
+        assert_eq!(results[1].relative, PathBuf::from("src/lib.rs"));
+        assert_eq!(results[2].relative, PathBuf::from("tests/foo.rs"));
+    }
+
+    /// Given: empty fd output
+    /// When: parse_fd_output is called
+    /// Then: empty vec is returned
+    #[test]
+    fn parse_fd_output_empty_string_returns_empty() {
+        let root = Path::new("/tmp");
+        let results = parse_fd_output("", root);
+        assert!(results.is_empty());
+    }
+
+    /// Given: fd output with more than MAX_FIND_RESULTS lines
+    /// When: parse_fd_output is called
+    /// Then: exactly MAX_FIND_RESULTS results are returned
+    #[test]
+    fn parse_fd_output_truncates_at_max() {
+        let root = Path::new("/tmp");
+        let output: String = (0..600).map(|i| format!("file{i}.rs\n")).collect();
+        let results = parse_fd_output(&output, root);
+        assert_eq!(results.len(), MAX_FIND_RESULTS);
+    }
+
+    /// Given: results with exact, prefix, and substring matches for "main"
+    /// When: sort_results is called
+    /// Then: exact comes first, prefix second, substring last
+    #[test]
+    fn sort_results_orders_exact_prefix_substring() {
+        let root = Path::new("/tmp");
+        let mut results = vec![
+            make_result("src/not_main_thing.rs", root),
+            make_result("src/main_loop.rs", root),
+            make_result("src/main.rs", root),
+        ];
+        sort_results("main", &mut results);
+        assert_eq!(results[0].relative.file_name().unwrap(), "main.rs");
+        assert_eq!(results[1].relative.file_name().unwrap(), "main_loop.rs");
+        assert_eq!(
+            results[2].relative.file_name().unwrap(),
+            "not_main_thing.rs"
+        );
+    }
+
+    /// Given: an empty query string
+    /// When: run_find is called
+    /// Then: returns Ok with an empty vec without touching the filesystem
+    #[test]
+    fn run_find_empty_query_returns_empty() {
+        let root = std::env::temp_dir();
+        let results = run_find("", &root).unwrap();
+        assert!(results.is_empty());
+    }
+
+    /// Given: a temp directory containing a uniquely named file
+    /// When: run_walker is called with a query matching that filename
+    /// Then: the result contains the file's absolute path
+    #[test]
+    fn walker_finds_file_in_temp_dir() {
+        let tmp = std::env::temp_dir();
+        let fname = format!("trek_walker_test_{}.txt", std::process::id());
+        let fpath = tmp.join(&fname);
+        fs::write(&fpath, b"hello").unwrap();
+
+        let results = run_walker("trek_walker_test", &tmp);
+        let _ = fs::remove_file(&fpath);
+
+        assert!(
+            results.iter().any(|r| r.absolute == fpath),
+            "expected to find {fname} in results: {results:?}",
+        );
+    }
+
+    /// Given: a temp directory with a hidden subdirectory containing a file
+    /// When: run_walker is called with a query matching that file's name
+    /// Then: the hidden directory's contents are not returned
+    #[test]
+    fn walker_skips_hidden_directories() {
+        let tmp = std::env::temp_dir();
+        let hidden_dir = tmp.join(format!(".trek_hidden_{}", std::process::id()));
+        let _ = fs::create_dir_all(&hidden_dir);
+        let fname = format!("trek_hidden_file_{}.txt", std::process::id());
+        let hidden_file = hidden_dir.join(&fname);
+        let _ = fs::write(&hidden_file, b"hidden");
+
+        let results = run_walker(&fname, &tmp);
+
+        let _ = fs::remove_file(&hidden_file);
+        let _ = fs::remove_dir(&hidden_dir);
+
+        assert!(
+            !results.iter().any(|r| r.absolute == hidden_file),
+            "walker must not descend into hidden directories"
+        );
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 mod app;
 mod archive;
+mod find;
 mod git;
 mod highlight;
 mod icons;
@@ -322,6 +323,21 @@ fn run(
                         KeyCode::Char(c) => app.rename_push_char(c),
                         _ => {}
                     }
+                } else if app.find_mode {
+                    match key.code {
+                        KeyCode::Esc => app.cancel_find(),
+                        KeyCode::Char('p') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                            app.cancel_find()
+                        }
+                        KeyCode::Enter | KeyCode::Char('l') | KeyCode::Right => {
+                            app.jump_to_find_result()
+                        }
+                        KeyCode::Backspace => app.find_pop_char(),
+                        KeyCode::Up | KeyCode::Char('k') => app.find_move_up(),
+                        KeyCode::Down | KeyCode::Char('j') => app.find_move_down(),
+                        KeyCode::Char(c) => app.find_push_char(c),
+                        _ => {}
+                    }
                 } else if app.search_mode {
                     match key.code {
                         KeyCode::Esc => app.cancel_search(),
@@ -336,6 +352,9 @@ fn run(
                     match key.code {
                         KeyCode::Char('f') if key.modifiers.contains(KeyModifiers::CONTROL) => {
                             app.start_content_search()
+                        }
+                        KeyCode::Char('p') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                            app.start_find()
                         }
                         KeyCode::Char('Q') | KeyCode::Char('q') => break,
                         KeyCode::Up | KeyCode::Char('k') => app.move_up(),
@@ -363,7 +382,9 @@ fn run(
                         KeyCode::Char('c') => app.clipboard_copy_current(),
                         KeyCode::Char('C') => app.clipboard_copy_selected(),
                         KeyCode::Char('x') => app.clipboard_cut_current(),
-                        KeyCode::Char('p') => app.paste_clipboard(),
+                        KeyCode::Char('p') if !key.modifiers.contains(KeyModifiers::CONTROL) => {
+                            app.paste_clipboard()
+                        }
                         KeyCode::Delete => app.begin_delete_current(),
                         KeyCode::Char('X') => app.begin_delete_selected(),
                         KeyCode::Char('M') => app.begin_mkdir(),

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -85,6 +85,8 @@ pub fn draw(f: &mut Frame, app: &mut App) {
         draw_rename_preview_pane(f, app, pane_chunks[1]);
     } else if app.content_search_mode {
         draw_content_search_pane(f, app, pane_chunks[1]);
+    } else if app.find_mode {
+        draw_find_pane(f, app, pane_chunks[1]);
     } else {
         draw_current_pane(f, app, pane_chunks[1]);
     }
@@ -99,6 +101,8 @@ pub fn draw(f: &mut Frame, app: &mut App) {
         draw_mkdir_bar(f, app, bottom_area);
     } else if app.content_search_mode {
         draw_content_search_bar(f, app, bottom_area);
+    } else if app.find_mode {
+        draw_find_bar(f, app, bottom_area);
     } else if app.search_mode {
         draw_search_bar(f, app, bottom_area);
     } else if let Some(ref msg) = app.status_message {
@@ -924,6 +928,89 @@ fn key_line(key: &'static str, desc: &'static str) -> Line<'static> {
     ])
 }
 
+/// Render recursive find results in the center pane during find mode.
+fn draw_find_pane(f: &mut Frame, app: &App, area: Rect) {
+    let count = app.find_results.len();
+    let title = if app.find_query.is_empty() {
+        " Find files ".to_string()
+    } else if count == 0 {
+        " No matches ".to_string()
+    } else {
+        let trunc = if app.find_truncated {
+            " [truncated]"
+        } else {
+            ""
+        };
+        format!(
+            " {} file{}{} ",
+            count,
+            if count == 1 { "" } else { "s" },
+            trunc
+        )
+    };
+
+    let visible_height = area.height.saturating_sub(2) as usize;
+    let scroll = if app.find_selected >= visible_height {
+        app.find_selected - visible_height + 1
+    } else {
+        0
+    };
+
+    let items: Vec<ListItem> = app
+        .find_results
+        .iter()
+        .enumerate()
+        .skip(scroll)
+        .take(visible_height)
+        .map(|(i, r)| {
+            let is_selected = i == app.find_selected;
+            let style = if is_selected {
+                Style::default()
+                    .fg(Color::White)
+                    .bg(Color::Blue)
+                    .add_modifier(Modifier::BOLD)
+            } else {
+                Style::default()
+            };
+            ListItem::new(Line::from(Span::styled(
+                format!(" {}", r.relative.display()),
+                style,
+            )))
+        })
+        .collect();
+
+    let list = List::new(items).block(
+        Block::default()
+            .borders(Borders::TOP | Borders::BOTTOM | Borders::RIGHT)
+            .border_style(Style::default().fg(Color::DarkGray))
+            .title(title),
+    );
+    f.render_widget(list, area);
+}
+
+/// Render the find prompt in the status bar.
+fn draw_find_bar(f: &mut Frame, app: &App, area: Rect) {
+    if let Some(ref err) = app.find_error {
+        let para = Paragraph::new(Line::from(Span::styled(
+            format!(" \u{26a0} {}", err),
+            Style::default().fg(Color::Red),
+        )));
+        f.render_widget(para, area);
+        return;
+    }
+    let para = Paragraph::new(Line::from(vec![
+        Span::styled(
+            "Find: ",
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(app.find_query.as_str(), Style::default().fg(Color::White)),
+        Span::styled("█", Style::default().fg(Color::Yellow)),
+    ]));
+    f.render_widget(para, area);
+}
+
 fn draw_help_overlay(f: &mut Frame, size: Rect) {
     let width = 60u16.min(size.width.saturating_sub(4));
     let height = 46u16.min(size.height.saturating_sub(4));
@@ -951,6 +1038,7 @@ fn draw_help_overlay(f: &mut Frame, size: Rect) {
         section_header("Search"),
         key_line("/", "Fuzzy search"),
         key_line("Ctrl+F", "Content search (ripgrep)"),
+        key_line("Ctrl+P", "Recursive filename find"),
         Line::from(""),
         // ── View ────────────────────────────────────────────────────────────
         section_header("View"),


### PR DESCRIPTION
## Summary

- New `Ctrl+P` keybinding opens a live recursive filename finder
- Results update on every keystroke; sorted by relevance (exact stem → prefix → substring)
- Prefers `fd` when available; built-in walker as fallback (skips hidden dirs, `target/`, `node_modules/`)
- Results capped at 500 with truncation notice
- `j`/`k` navigate; `l`/`Enter`/`→` jumps to file and pushes history entry; `Esc` cancels

## Test plan

- [ ] 7 new unit tests pass (`cargo test`) covering output parsing, empty-query short-circuit, truncation, relevance sorting, walker finds, and hidden-dir skip
- [ ] `cargo clippy -- -D warnings` passes clean
- [ ] `cargo build --release` succeeds
- [ ] Manual test: press `Ctrl+P`, type a filename fragment, navigate results with `j`/`k`, press `Enter` to jump
- [ ] Verify `Ctrl+O` returns to previous location after jumping

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)