### PR TITLE
feat(nav): persistent directory bookmarks (b/B)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.0] - 2026-03-24
+
+### Added
+- Persistent directory bookmarks: `b` saves the current directory; `B` opens a centered picker overlay
+- Bookmarks stored at `$XDG_DATA_HOME/trek/bookmarks` (fallback: `~/.local/share/trek/bookmarks`) — plain text, one path per line, insertion order
+- Duplicate paths silently deduplicated on `b`
+- Picker supports `j`/`k` and arrow navigation; `Enter` jumps to the selected bookmark and pushes a history entry; `Esc` or `B` closes without navigating; `d` removes the focused bookmark instantly
+- Typing while the picker is open filters by name or path; `Backspace` removes the last filter character
+- Stale bookmarks (non-existent paths) shown dimmed with `[gone]`; navigating to one shows an error message instead of crashing
+- Empty state shows `"No bookmarks — press b to add one"` in the picker
+- Help overlay documents `b` and `B` under the Search section
+- New `src/bookmarks.rs` module: `load`, `add`, `remove`, `save`; 6 unit tests covering load-empty, add-then-load, deduplication, remove-at-index, out-of-range remove, and XDG path resolution
+
 ## [0.12.0] - 2026-03-24
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trek"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 rust-version = "1.80"
 description = "A terminal file manager with mouse-resizable panes"

--- a/src/app.rs
+++ b/src/app.rs
@@ -190,6 +190,18 @@ pub struct App {
     /// Current sort direction.
     pub sort_order: SortOrder,
 
+    // --- Bookmarks (b / B) ---
+    /// True while the bookmark picker overlay is open.
+    pub bookmark_mode: bool,
+    /// All bookmarks loaded from disk when the picker opens.
+    pub bookmarks: Vec<PathBuf>,
+    /// Index into `bookmark_filtered` of the highlighted row.
+    pub bookmark_selected: usize,
+    /// Filter string typed while the picker is open.
+    pub bookmark_query: String,
+    /// Indices into `bookmarks` that pass the current filter.
+    pub bookmark_filtered: Vec<usize>,
+
     // --- Recursive find (Ctrl+P) ---
     /// True while the recursive filename find overlay is open.
     pub find_mode: bool,
@@ -278,6 +290,11 @@ impl App {
             rename_error: None,
             sort_mode: SortMode::default(),
             sort_order: SortOrder::default(),
+            bookmark_mode: false,
+            bookmarks: Vec::new(),
+            bookmark_selected: 0,
+            bookmark_query: String::new(),
+            bookmark_filtered: Vec::new(),
             find_mode: false,
             find_query: String::new(),
             find_results: Vec::new(),
@@ -1503,6 +1520,110 @@ impl App {
                 self.preview_scroll = (target_line as usize).saturating_sub(1);
             }
         }
+    }
+
+    // --- Bookmarks (b / B) ---
+
+    /// Bookmark the current directory.
+    pub fn add_bookmark(&mut self) {
+        match crate::bookmarks::add(&self.cwd) {
+            Ok(()) => self.status_message = Some(format!("Bookmarked {}", self.cwd.display())),
+            Err(e) => self.status_message = Some(format!("Bookmark failed: {e}")),
+        }
+    }
+
+    /// Open the bookmark picker overlay.
+    pub fn open_bookmarks(&mut self) {
+        self.bookmarks = crate::bookmarks::load();
+        self.bookmark_query.clear();
+        self.bookmark_filtered = (0..self.bookmarks.len()).collect();
+        self.bookmark_selected = 0;
+        self.bookmark_mode = true;
+    }
+
+    /// Close the picker without navigating.
+    pub fn close_bookmarks(&mut self) {
+        self.bookmark_mode = false;
+        self.bookmark_query.clear();
+    }
+
+    /// Navigate to the currently focused bookmark.
+    pub fn confirm_bookmark(&mut self) {
+        let Some(&real_idx) = self.bookmark_filtered.get(self.bookmark_selected) else {
+            return;
+        };
+        let Some(dest) = self.bookmarks.get(real_idx).cloned() else {
+            return;
+        };
+        self.close_bookmarks();
+        if !dest.is_dir() {
+            self.status_message = Some(format!("\"{}\" no longer exists", dest.display()));
+            return;
+        }
+        self.push_history(dest.clone());
+        self.cwd = dest;
+        self.selected = 0;
+        self.current_scroll = 0;
+        self.load_dir();
+    }
+
+    /// Remove the focused bookmark from disk immediately.
+    pub fn remove_bookmark(&mut self) {
+        let Some(&real_idx) = self.bookmark_filtered.get(self.bookmark_selected) else {
+            return;
+        };
+        let _ = crate::bookmarks::remove(real_idx);
+        self.bookmarks = crate::bookmarks::load();
+        self.update_bookmark_filter();
+        if !self.bookmark_filtered.is_empty() {
+            self.bookmark_selected = self
+                .bookmark_selected
+                .min(self.bookmark_filtered.len().saturating_sub(1));
+        }
+    }
+
+    /// Append a character to the bookmark filter and re-filter.
+    pub fn bookmark_push_char(&mut self, c: char) {
+        self.bookmark_query.push(c);
+        self.update_bookmark_filter();
+        self.bookmark_selected = 0;
+    }
+
+    /// Remove the last character from the bookmark filter and re-filter.
+    pub fn bookmark_pop_char(&mut self) {
+        self.bookmark_query.pop();
+        self.update_bookmark_filter();
+        self.bookmark_selected = 0;
+    }
+
+    /// Move selection up in the bookmark picker.
+    pub fn bookmark_move_up(&mut self) {
+        self.bookmark_selected = self.bookmark_selected.saturating_sub(1);
+    }
+
+    /// Move selection down in the bookmark picker.
+    pub fn bookmark_move_down(&mut self) {
+        if !self.bookmark_filtered.is_empty()
+            && self.bookmark_selected + 1 < self.bookmark_filtered.len()
+        {
+            self.bookmark_selected += 1;
+        }
+    }
+
+    /// Recompute `bookmark_filtered` from the current query.
+    fn update_bookmark_filter(&mut self) {
+        if self.bookmark_query.is_empty() {
+            self.bookmark_filtered = (0..self.bookmarks.len()).collect();
+            return;
+        }
+        let q = self.bookmark_query.to_lowercase();
+        self.bookmark_filtered = self
+            .bookmarks
+            .iter()
+            .enumerate()
+            .filter(|(_, p)| p.to_string_lossy().to_lowercase().contains(&q))
+            .map(|(i, _)| i)
+            .collect();
     }
 
     // --- Recursive find (Ctrl+P) ---

--- a/src/bookmarks.rs
+++ b/src/bookmarks.rs
@@ -1,0 +1,191 @@
+//! Persistent directory bookmarks.
+//!
+//! Bookmarks are stored at `$XDG_DATA_HOME/trek/bookmarks` (falling back to
+//! `~/.local/share/trek/bookmarks`) — one absolute path per line, in
+//! insertion order.  No external crate dependencies.
+
+use std::io::{BufRead, Write};
+use std::path::{Path, PathBuf};
+
+/// Return the path of the bookmarks file.
+pub fn bookmarks_path() -> PathBuf {
+    let base = std::env::var_os("XDG_DATA_HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| {
+            let home = std::env::var_os("HOME").unwrap_or_default();
+            PathBuf::from(home).join(".local/share")
+        });
+    base.join("trek").join("bookmarks")
+}
+
+/// Load bookmarks from disk.  Returns an empty `Vec` if the file does not
+/// exist or cannot be read.
+pub fn load() -> Vec<PathBuf> {
+    let Ok(file) = std::fs::File::open(bookmarks_path()) else {
+        return Vec::new();
+    };
+    std::io::BufReader::new(file)
+        .lines()
+        .map_while(Result::ok)
+        .map(|l| l.trim().to_owned())
+        .filter(|l| !l.is_empty())
+        .map(PathBuf::from)
+        .collect()
+}
+
+/// Add `dir` to the bookmarks list.  Silently deduplicates — if `dir` is
+/// already bookmarked, this is a no-op.
+pub fn add(dir: &Path) -> std::io::Result<()> {
+    let mut bms = load();
+    if bms.iter().any(|b| b == dir) {
+        return Ok(());
+    }
+    bms.push(dir.to_path_buf());
+    save(&bms)
+}
+
+/// Remove the bookmark at `index` (into the list returned by `load()`).
+/// Out-of-range indices are silently ignored.
+pub fn remove(index: usize) -> std::io::Result<()> {
+    let mut bms = load();
+    if index < bms.len() {
+        bms.remove(index);
+        save(&bms)?;
+    }
+    Ok(())
+}
+
+/// Write `bms` to disk, creating parent directories as needed.
+fn save(bms: &[PathBuf]) -> std::io::Result<()> {
+    let path = bookmarks_path();
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let mut f = std::fs::File::create(&path)?;
+    for b in bms {
+        writeln!(f, "{}", b.display())?;
+    }
+    Ok(())
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::sync::Mutex;
+
+    /// Serializes all bookmark tests that mutate `XDG_DATA_HOME`.
+    /// Env var mutation is process-global, so tests touching it must not run
+    /// concurrently.
+    static BM_LOCK: Mutex<()> = Mutex::new(());
+
+    /// Run `f` inside a temp directory used as `XDG_DATA_HOME`, restoring the
+    /// previous value afterwards.
+    fn with_temp_bookmarks<F: FnOnce(&Path)>(f: F) {
+        let _guard = BM_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+
+        // Use a pid+counter suffix to avoid clashing between parallel test
+        // binaries (different processes can share /tmp).
+        static COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+        let n = COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+
+        let tmp = std::env::temp_dir().join(format!("trek_bm_test_{}_{}", std::process::id(), n));
+        let _ = fs::create_dir_all(&tmp);
+
+        let prev = std::env::var_os("XDG_DATA_HOME");
+        std::env::set_var("XDG_DATA_HOME", &tmp);
+        f(&tmp);
+        match prev {
+            Some(v) => std::env::set_var("XDG_DATA_HOME", v),
+            None => std::env::remove_var("XDG_DATA_HOME"),
+        }
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    /// Given: no bookmarks file exists
+    /// When: load() is called
+    /// Then: an empty Vec is returned without panicking
+    #[test]
+    fn load_returns_empty_when_no_file() {
+        with_temp_bookmarks(|_| {
+            let bms = load();
+            assert!(bms.is_empty());
+        });
+    }
+
+    /// Given: a directory is added as a bookmark
+    /// When: load() is called
+    /// Then: the bookmark is present in the returned list
+    #[test]
+    fn add_then_load_returns_bookmark() {
+        with_temp_bookmarks(|_| {
+            let dir = std::env::temp_dir();
+            add(&dir).unwrap();
+            let bms = load();
+            assert!(bms.contains(&dir), "bookmark should be present after add");
+        });
+    }
+
+    /// Given: the same directory is added twice
+    /// When: load() is called
+    /// Then: only one entry exists (silent deduplication)
+    #[test]
+    fn add_deduplicates_silently() {
+        with_temp_bookmarks(|_| {
+            let dir = std::env::temp_dir();
+            add(&dir).unwrap();
+            add(&dir).unwrap();
+            let bms = load();
+            let count = bms.iter().filter(|b| *b == &dir).count();
+            assert_eq!(count, 1, "duplicate should be silently ignored");
+        });
+    }
+
+    /// Given: two bookmarks are saved, then remove(0) is called
+    /// When: load() is called
+    /// Then: only the second bookmark remains
+    #[test]
+    fn remove_at_index_zero_removes_first() {
+        with_temp_bookmarks(|_| {
+            let a = PathBuf::from("/tmp/trek_bm_a");
+            let b = PathBuf::from("/tmp/trek_bm_b");
+            save(&[a.clone(), b.clone()]).unwrap();
+            remove(0).unwrap();
+            let bms = load();
+            assert_eq!(bms, vec![b]);
+        });
+    }
+
+    /// Given: an out-of-range index is passed to remove()
+    /// When: remove() is called
+    /// Then: it returns Ok(()) without panicking or modifying the list
+    #[test]
+    fn remove_out_of_range_is_noop() {
+        with_temp_bookmarks(|_| {
+            let dir = std::env::temp_dir();
+            add(&dir).unwrap();
+            assert!(remove(99).is_ok());
+            let bms = load();
+            assert_eq!(bms.len(), 1, "list should be unchanged");
+        });
+    }
+
+    /// Given: bookmarks_path() is called with XDG_DATA_HOME set
+    /// When: the path is inspected
+    /// Then: it starts with the XDG_DATA_HOME value and ends with trek/bookmarks
+    #[test]
+    fn bookmarks_path_uses_xdg_data_home() {
+        with_temp_bookmarks(|tmp| {
+            let path = bookmarks_path();
+            assert!(
+                path.starts_with(tmp),
+                "expected path under {}, got {}",
+                tmp.display(),
+                path.display()
+            );
+            assert!(path.ends_with("trek/bookmarks"));
+        });
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 mod app;
 mod archive;
+mod bookmarks;
 mod find;
 mod git;
 mod highlight;
@@ -323,6 +324,18 @@ fn run(
                         KeyCode::Char(c) => app.rename_push_char(c),
                         _ => {}
                     }
+                } else if app.bookmark_mode {
+                    match key.code {
+                        KeyCode::Esc => app.close_bookmarks(),
+                        KeyCode::Char('B') => app.close_bookmarks(),
+                        KeyCode::Enter => app.confirm_bookmark(),
+                        KeyCode::Char('d') => app.remove_bookmark(),
+                        KeyCode::Up | KeyCode::Char('k') => app.bookmark_move_up(),
+                        KeyCode::Down | KeyCode::Char('j') => app.bookmark_move_down(),
+                        KeyCode::Backspace => app.bookmark_pop_char(),
+                        KeyCode::Char(c) => app.bookmark_push_char(c),
+                        _ => {}
+                    }
                 } else if app.find_mode {
                     match key.code {
                         KeyCode::Esc => app.cancel_find(),
@@ -388,6 +401,8 @@ fn run(
                         KeyCode::Delete => app.begin_delete_current(),
                         KeyCode::Char('X') => app.begin_delete_selected(),
                         KeyCode::Char('M') => app.begin_mkdir(),
+                        KeyCode::Char('b') => app.add_bookmark(),
+                        KeyCode::Char('B') => app.open_bookmarks(),
                         KeyCode::Char('S') => app.cycle_sort_mode(),
                         KeyCode::Char('s') => app.toggle_sort_order(),
                         KeyCode::Char('o') if key.modifiers.contains(KeyModifiers::CONTROL) => {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -163,6 +163,11 @@ pub fn draw(f: &mut Frame, app: &mut App) {
     if app.show_help {
         draw_help_overlay(f, size);
     }
+
+    // Bookmark picker overlay (rendered on top of everything else).
+    if app.bookmark_mode {
+        draw_bookmark_overlay(f, app, size);
+    }
 }
 
 fn draw_path_bar(f: &mut Frame, app: &App, area: Rect) {
@@ -988,6 +993,156 @@ fn draw_find_pane(f: &mut Frame, app: &App, area: Rect) {
     f.render_widget(list, area);
 }
 
+/// Render the bookmark picker as a centered overlay.
+fn draw_bookmark_overlay(f: &mut Frame, app: &App, size: Rect) {
+    // Compute overlay dimensions.  Minimum usable height is 6 rows.
+    let width = 62u16.min(size.width.saturating_sub(4));
+    let max_rows = app.bookmark_filtered.len().max(1) as u16;
+    let height = (max_rows + 4).min(size.height.saturating_sub(4)).max(6);
+    let x = (size.width.saturating_sub(width)) / 2;
+    let y = (size.height.saturating_sub(height)) / 2;
+    let area = Rect::new(x, y, width, height);
+
+    f.render_widget(Clear, area);
+
+    // Title: show filter query when active.
+    let title = if app.bookmark_query.is_empty() {
+        " Bookmarks ".to_string()
+    } else {
+        format!(" Bookmarks  {} ", app.bookmark_query)
+    };
+
+    // Hint in title right section — put it in the title for simplicity.
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Cyan))
+        .title(Span::styled(
+            title,
+            Style::default()
+                .fg(Color::White)
+                .add_modifier(Modifier::BOLD),
+        ));
+
+    let inner = block.inner(area);
+    f.render_widget(block, area);
+
+    let visible_height = inner.height as usize;
+    let name_col = 16usize; // chars reserved for short name
+
+    if app.bookmark_filtered.is_empty() {
+        let msg = if app.bookmarks.is_empty() {
+            "  No bookmarks — press b to add one"
+        } else {
+            "  No matches"
+        };
+        let para = Paragraph::new(Line::from(Span::styled(
+            msg,
+            Style::default().fg(Color::DarkGray),
+        )));
+        f.render_widget(para, inner);
+        return;
+    }
+
+    let scroll = if app.bookmark_selected >= visible_height {
+        app.bookmark_selected - visible_height + 1
+    } else {
+        0
+    };
+
+    let path_width = (inner.width as usize).saturating_sub(name_col + 2);
+
+    let items: Vec<ListItem> = app
+        .bookmark_filtered
+        .iter()
+        .enumerate()
+        .skip(scroll)
+        .take(visible_height)
+        .map(|(display_idx, &real_idx)| {
+            let path = &app.bookmarks[real_idx];
+            let exists = path.is_dir();
+            let is_selected = display_idx == app.bookmark_selected;
+
+            // Short name = last path component.
+            let short = path
+                .file_name()
+                .map(|n| n.to_string_lossy().into_owned())
+                .unwrap_or_else(|| path.to_string_lossy().into_owned());
+            let short_col = truncate_with_ellipsis(&short, name_col);
+
+            let full = path.to_string_lossy().into_owned();
+            // Replace $HOME with ~
+            let home = std::env::var("HOME").unwrap_or_default();
+            let display_path = if !home.is_empty() && full.starts_with(&home) {
+                format!("~{}", &full[home.len()..])
+            } else {
+                full
+            };
+            let path_col = truncate_with_ellipsis(&display_path, path_width);
+
+            let gone_suffix = if exists { "" } else { "  [gone]" };
+
+            if is_selected {
+                let style = Style::default()
+                    .fg(Color::White)
+                    .bg(Color::Blue)
+                    .add_modifier(Modifier::BOLD);
+                ListItem::new(Line::from(vec![
+                    Span::styled(format!(" {:<width$}", short_col, width = name_col), style),
+                    Span::styled(format!("{}{}", path_col, gone_suffix), style),
+                ]))
+            } else if !exists {
+                let style = Style::default().fg(Color::DarkGray);
+                ListItem::new(Line::from(vec![
+                    Span::styled(format!(" {:<width$}", short_col, width = name_col), style),
+                    Span::styled(format!("{}{}", path_col, gone_suffix), style),
+                ]))
+            } else {
+                ListItem::new(Line::from(vec![
+                    Span::styled(
+                        format!(" {:<width$}", short_col, width = name_col),
+                        Style::default().fg(Color::Cyan),
+                    ),
+                    Span::raw(path_col),
+                ]))
+            }
+        })
+        .collect();
+
+    let hint = Paragraph::new(Line::from(vec![
+        Span::styled(
+            "  Enter",
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(": jump  ", Style::default().fg(Color::DarkGray)),
+        Span::styled(
+            "d",
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(": remove  ", Style::default().fg(Color::DarkGray)),
+        Span::styled(
+            "Esc",
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(": close", Style::default().fg(Color::DarkGray)),
+    ]));
+
+    // Split inner area: list rows above, hint row at bottom.
+    let inner_chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Min(1), Constraint::Length(1)])
+        .split(inner);
+
+    let list = List::new(items);
+    f.render_widget(list, inner_chunks[0]);
+    f.render_widget(hint, inner_chunks[1]);
+}
+
 /// Render the find prompt in the status bar.
 fn draw_find_bar(f: &mut Frame, app: &App, area: Rect) {
     if let Some(ref err) = app.find_error {
@@ -1039,6 +1194,8 @@ fn draw_help_overlay(f: &mut Frame, size: Rect) {
         key_line("/", "Fuzzy search"),
         key_line("Ctrl+F", "Content search (ripgrep)"),
         key_line("Ctrl+P", "Recursive filename find"),
+        key_line("b", "Bookmark current directory"),
+        key_line("B", "Open bookmark picker"),
         Line::from(""),
         // ── View ────────────────────────────────────────────────────────────
         section_header("View"),


### PR DESCRIPTION
## Summary

- `b` saves the current directory to `~/.local/share/trek/bookmarks` (XDG-aware) with silent deduplication and a confirmation status message
- `B` opens a centered picker overlay; `j`/`k` navigate; `Enter` jumps (pushes a history entry); `d` removes the focused bookmark instantly; `Esc`/`B` closes
- Typing while picker is open filters by name or path; `Backspace` removes last filter character
- Stale (non-existent) paths shown dimmed with `[gone]`; navigating to one shows an error instead of crashing
- Empty state shows a helpful message
- Help overlay documents `b` and `B`
- New `src/bookmarks.rs`: `load`, `add`, `remove`, `save`; no new crate deps

## Test plan

- [ ] 6 unit tests pass: load-empty, add-then-load, dedup, remove-at-index-0, out-of-range remove, XDG path resolution
- [ ] `cargo clippy -- -D warnings` clean
- [ ] `cargo build --release` succeeds
- [ ] Manual: press `b` in a directory → status message appears; press `B` → picker opens with entry; `Enter` navigates; `Ctrl+O` returns
- [ ] Manual: `d` removes bookmark from list and disk; stale paths show `[gone]`

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)