### PR TITLE
feat(preview): file metadata view (m) and chmod editor (P)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.0] - 2026-03-24
+
+### Added
+- **`m` — metadata preview**: toggles the preview pane to a structured info card showing path, type, size (human-readable + raw bytes), Unix mode (symbolic `rwxrwxrwx` and octal), UID/GID, modified time, and accessed time; pane title shows `filename [meta]`; mutually exclusive with diff mode (`d`)
+- **`P` — chmod editor**: opens an inline input bar showing the current octal mode; input restricted to digits 0–7 (max 4 chars); `Enter` applies via `std::fs::set_permissions`, `Esc` cancels; metadata card refreshes immediately on success; non-Unix platforms show a descriptive message
+- `m` and `P` documented in the help overlay (`?`) under View
+- New helper functions: `format_permission_bits`, `meta_human_size`, `format_unix_timestamp_utc` (pure Rust UTC arithmetic, no subprocess)
+- 6 new unit tests covering permission bit formatting, human-readable sizes, and UTC timestamp formatting (epoch + known date)
+
 ## [0.14.0] - 2026-03-24
 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trek"
-version = "0.14.0"
+version = "0.15.0"
 edition = "2021"
 rust-version = "1.80"
 description = "A terminal file manager with mouse-resizable panes"

--- a/src/app.rs
+++ b/src/app.rs
@@ -141,6 +141,16 @@ pub struct App {
     /// True when `preview_lines` holds diff output (used by the renderer to colorise lines).
     pub preview_is_diff: bool,
 
+    // --- Metadata preview (m) ---
+    /// When true the preview pane shows the file metadata card instead of content.
+    pub meta_preview_mode: bool,
+
+    // --- chmod editor (P) ---
+    /// True while the chmod input bar is open.
+    pub chmod_mode: bool,
+    /// Octal string currently typed in the chmod bar (max 4 chars).
+    pub chmod_input: String,
+
     // --- Syntax highlighter (initialized once at startup) ---
     pub highlighter: Highlighter,
 
@@ -272,6 +282,9 @@ impl App {
             git_status: None,
             diff_preview_mode: false,
             preview_is_diff: false,
+            meta_preview_mode: false,
+            chmod_mode: false,
+            chmod_input: String::new(),
             highlighter: Highlighter::new(),
             clipboard: None,
             pending_delete: Vec::new(),
@@ -445,6 +458,14 @@ impl App {
         self.preview_lines.clear();
         self.preview_is_diff = false;
 
+        // Metadata card takes priority over content/diff views.
+        if self.meta_preview_mode {
+            if let Some(entry) = self.entries.get(self.selected).cloned() {
+                self.preview_lines = Self::load_meta_lines(&entry.path);
+            }
+            return;
+        }
+
         if let Some(entry) = self.entries.get(self.selected).cloned() {
             if entry.is_dir {
                 // Directories never show a diff preview.
@@ -542,6 +563,9 @@ impl App {
 
         if has_git_change {
             self.diff_preview_mode = !self.diff_preview_mode;
+            if self.diff_preview_mode {
+                self.meta_preview_mode = false; // mutually exclusive
+            }
             self.load_preview();
         } else {
             self.status_message = Some("No git changes for this file".to_string());
@@ -1826,6 +1850,223 @@ impl App {
         let _ = std::io::stdout().write_all(seq.as_bytes());
         let _ = std::io::stdout().flush();
     }
+
+    // --- Metadata preview (m) ---
+
+    /// Toggle between content preview and metadata preview.
+    pub fn toggle_meta_preview(&mut self) {
+        self.meta_preview_mode = !self.meta_preview_mode;
+        if self.meta_preview_mode {
+            self.diff_preview_mode = false; // mutually exclusive
+        }
+        self.load_preview();
+    }
+
+    /// Build the metadata card lines for `path`.
+    fn load_meta_lines(path: &Path) -> Vec<String> {
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::{MetadataExt, PermissionsExt};
+            let meta = match std::fs::symlink_metadata(path) {
+                Ok(m) => m,
+                Err(e) => return vec![String::new(), format!("  Error reading metadata: {}", e)],
+            };
+            let size = meta.len();
+            let file_type = if meta.is_dir() {
+                "Directory"
+            } else if meta.file_type().is_symlink() {
+                "Symbolic link"
+            } else {
+                "Regular file"
+            };
+            let mode = meta.permissions().mode();
+            let fmt_time = |st: std::io::Result<std::time::SystemTime>| -> String {
+                st.ok()
+                    .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+                    .map(|d| format_unix_timestamp_utc(d.as_secs()))
+                    .unwrap_or_else(|| "unavailable".to_string())
+            };
+            vec![
+                String::new(),
+                format!("  Path      {}", path.display()),
+                format!("  Type      {}", file_type),
+                format!("  Size      {} ({} bytes)", meta_human_size(size), size),
+                format!(
+                    "  Mode      {} ({:04o})",
+                    format_permission_bits(mode),
+                    mode & 0o7777
+                ),
+                format!("  UID / GID {} / {}", meta.uid(), meta.gid()),
+                format!("  Modified  {}", fmt_time(meta.modified())),
+                format!("  Accessed  {}", fmt_time(meta.accessed())),
+            ]
+        }
+        #[cfg(not(unix))]
+        {
+            vec![
+                String::new(),
+                format!("  Path     {}", path.display()),
+                "  (Full metadata not available on this platform)".to_string(),
+            ]
+        }
+    }
+
+    // --- chmod editor (P) ---
+
+    /// Open the chmod input bar for the currently selected entry.
+    pub fn begin_chmod(&mut self) {
+        if self.entries.get(self.selected).is_none() {
+            return;
+        }
+        self.chmod_mode = true;
+        self.chmod_input.clear();
+    }
+
+    /// Cancel the chmod input bar without making changes.
+    pub fn cancel_chmod(&mut self) {
+        self.chmod_mode = false;
+        self.chmod_input.clear();
+        self.status_message = Some("chmod cancelled".to_string());
+    }
+
+    /// Append an octal digit (max 4 chars).
+    pub fn chmod_push_char(&mut self, c: char) {
+        if self.chmod_input.len() < 4 {
+            self.chmod_input.push(c);
+        }
+    }
+
+    /// Remove the last digit from the chmod input.
+    pub fn chmod_pop_char(&mut self) {
+        self.chmod_input.pop();
+    }
+
+    /// Validate and apply the typed octal mode to the selected entry.
+    pub fn confirm_chmod(&mut self) {
+        let input = std::mem::take(&mut self.chmod_input);
+        self.chmod_mode = false;
+
+        let Some(entry) = self.entries.get(self.selected) else {
+            return;
+        };
+        let path = entry.path.clone();
+
+        if input.is_empty() {
+            self.status_message = Some("chmod cancelled (empty input)".to_string());
+            return;
+        }
+
+        let mode = match u32::from_str_radix(input.trim(), 8) {
+            Ok(m) if m <= 0o7777 => m,
+            _ => {
+                self.status_message = Some(format!("Invalid octal mode: '{}'", input));
+                return;
+            }
+        };
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            match std::fs::set_permissions(&path, std::fs::Permissions::from_mode(mode)) {
+                Ok(()) => {
+                    self.status_message = Some(format!("Mode set to {:04o}", mode));
+                    if self.meta_preview_mode {
+                        self.load_preview();
+                    }
+                }
+                Err(e) => self.status_message = Some(format!("chmod failed: {}", e)),
+            }
+        }
+        #[cfg(not(unix))]
+        {
+            let _ = (path, mode);
+            self.status_message = Some("chmod is not supported on this platform".to_string());
+        }
+    }
+}
+
+// ── Metadata helpers ──────────────────────────────────────────────────────────
+
+/// Format the 9 permission bits of a Unix mode as `rwxrwxrwx`.
+pub fn format_permission_bits(mode: u32) -> String {
+    let bit = |shift: u32, c: char| {
+        if mode & (1 << shift) != 0 {
+            c
+        } else {
+            '-'
+        }
+    };
+    format!(
+        "{}{}{}{}{}{}{}{}{}",
+        bit(8, 'r'),
+        bit(7, 'w'),
+        bit(6, 'x'),
+        bit(5, 'r'),
+        bit(4, 'w'),
+        bit(3, 'x'),
+        bit(2, 'r'),
+        bit(1, 'w'),
+        bit(0, 'x'),
+    )
+}
+
+/// Human-readable size with one decimal place (B / KB / MB / GB).
+pub fn meta_human_size(bytes: u64) -> String {
+    const KB: u64 = 1_024;
+    const MB: u64 = KB * 1_024;
+    const GB: u64 = MB * 1_024;
+    if bytes >= GB {
+        format!("{:.1} GB", bytes as f64 / GB as f64)
+    } else if bytes >= MB {
+        format!("{:.1} MB", bytes as f64 / MB as f64)
+    } else if bytes >= KB {
+        format!("{:.1} KB", bytes as f64 / KB as f64)
+    } else {
+        format!("{} B", bytes)
+    }
+}
+
+/// Format a UNIX timestamp as `YYYY-MM-DD HH:MM:SS` (UTC) without external
+/// crates or spawning a subprocess.
+pub fn format_unix_timestamp_utc(secs: u64) -> String {
+    let ss = secs % 60;
+    let mm = (secs / 60) % 60;
+    let hh = (secs / 3_600) % 24;
+    let mut days = secs / 86_400;
+
+    let mut year = 1970u32;
+    loop {
+        let dy = if is_leap_year(year) { 366u64 } else { 365 };
+        if days < dy {
+            break;
+        }
+        days -= dy;
+        year += 1;
+    }
+
+    let month_days: [u64; 12] = if is_leap_year(year) {
+        [31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+    } else {
+        [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+    };
+    let mut month = 1u32;
+    for &md in &month_days {
+        if days < md {
+            break;
+        }
+        days -= md;
+        month += 1;
+    }
+    let day = days + 1;
+
+    format!(
+        "{:04}-{:02}-{:02} {:02}:{:02}:{:02}",
+        year, month, day, hh, mm, ss
+    )
+}
+
+fn is_leap_year(y: u32) -> bool {
+    (y % 4 == 0 && y % 100 != 0) || y % 400 == 0
 }
 
 /// Format a file size in human-readable form.
@@ -2102,5 +2343,58 @@ mod tests {
             app.push_history(std::env::temp_dir());
         }
         assert!(app.history_len() <= MAX_HISTORY);
+    }
+
+    // ── Metadata helper tests ─────────────────────────────────────────────────
+
+    /// Given: Unix mode 0o644
+    /// When: format_permission_bits is called
+    /// Then: returns "rw-r--r--"
+    #[test]
+    fn permission_bits_0644() {
+        assert_eq!(format_permission_bits(0o644), "rw-r--r--");
+    }
+
+    /// Given: Unix mode 0o755
+    /// When: format_permission_bits is called
+    /// Then: returns "rwxr-xr-x"
+    #[test]
+    fn permission_bits_0755() {
+        assert_eq!(format_permission_bits(0o755), "rwxr-xr-x");
+    }
+
+    /// Given: 0 bytes
+    /// When: meta_human_size is called
+    /// Then: returns "0 B"
+    #[test]
+    fn human_size_zero_bytes() {
+        assert_eq!(meta_human_size(0), "0 B");
+    }
+
+    /// Given: exactly 1024 bytes
+    /// When: meta_human_size is called
+    /// Then: returns "1.0 KB"
+    #[test]
+    fn human_size_one_kb() {
+        assert_eq!(meta_human_size(1024), "1.0 KB");
+    }
+
+    /// Given: Unix timestamp 0 (epoch)
+    /// When: format_unix_timestamp_utc is called
+    /// Then: returns "1970-01-01 00:00:00"
+    #[test]
+    fn timestamp_epoch() {
+        assert_eq!(format_unix_timestamp_utc(0), "1970-01-01 00:00:00");
+    }
+
+    /// Given: Unix timestamp 1705318245 (2024-01-15 11:30:45 UTC)
+    /// When: format_unix_timestamp_utc is called
+    /// Then: returns the correct date/time string
+    #[test]
+    fn timestamp_known_date() {
+        assert_eq!(
+            format_unix_timestamp_utc(1_705_318_245),
+            "2024-01-15 11:30:45"
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -355,6 +355,14 @@ fn run(
                         KeyCode::Char(c) => app.find_push_char(c),
                         _ => {}
                     }
+                } else if app.chmod_mode {
+                    match key.code {
+                        KeyCode::Esc => app.cancel_chmod(),
+                        KeyCode::Enter => app.confirm_chmod(),
+                        KeyCode::Backspace => app.chmod_pop_char(),
+                        KeyCode::Char(c @ '0'..='7') => app.chmod_push_char(c),
+                        _ => {}
+                    }
                 } else if app.search_mode {
                     match key.code {
                         KeyCode::Esc => app.cancel_search(),
@@ -388,6 +396,8 @@ fn run(
                         KeyCode::Char('y') => app.yank_relative_path(),
                         KeyCode::Char('Y') => app.yank_absolute_path(),
                         KeyCode::Char('d') => app.toggle_diff_preview(),
+                        KeyCode::Char('m') => app.toggle_meta_preview(),
+                        KeyCode::Char('P') => app.begin_chmod(),
                         KeyCode::Char('R') => app.refresh_git_status(),
                         KeyCode::Char('?') => app.show_help = true,
                         // Bulk rename

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -99,6 +99,8 @@ pub fn draw(f: &mut Frame, app: &mut App) {
         draw_delete_confirm_bar(f, app, bottom_area);
     } else if app.mkdir_mode {
         draw_mkdir_bar(f, app, bottom_area);
+    } else if app.chmod_mode {
+        draw_chmod_bar(f, app, bottom_area);
     } else if app.content_search_mode {
         draw_content_search_bar(f, app, bottom_area);
     } else if app.find_mode {
@@ -273,6 +275,48 @@ fn draw_delete_confirm_bar(f: &mut Frame, app: &App, area: Rect) {
         Span::styled("delete permanently  ", Style::default().fg(Color::DarkGray)),
         Span::styled("[Esc]", Style::default().fg(Color::DarkGray)),
         Span::styled("cancel", Style::default().fg(Color::DarkGray)),
+    ]));
+    f.render_widget(para, area);
+}
+
+fn draw_chmod_bar(f: &mut Frame, app: &App, area: Rect) {
+    // Show the current octal mode as context.
+    let current = app
+        .entries
+        .get(app.selected)
+        .and_then(|e| std::fs::metadata(&e.path).ok())
+        .map(|m| {
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                format!("{:04o}", m.permissions().mode() & 0o7777)
+            }
+            #[cfg(not(unix))]
+            {
+                "????".to_string()
+            }
+        })
+        .unwrap_or_default();
+
+    let name = app
+        .entries
+        .get(app.selected)
+        .map(|e| e.name.as_str())
+        .unwrap_or("");
+
+    let para = Paragraph::new(Line::from(vec![
+        Span::styled(
+            format!(" chmod {} [current: {}]: ", name, current),
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(app.chmod_input.as_str(), Style::default().fg(Color::White)),
+        Span::styled("\u{2588}", Style::default().fg(Color::Yellow)),
+        Span::styled(
+            "  Enter=apply  Esc=cancel",
+            Style::default().fg(Color::DarkGray),
+        ),
     ]));
     f.render_widget(para, area);
 }
@@ -504,6 +548,8 @@ fn draw_preview_pane(f: &mut Frame, app: &App, area: Rect) {
         .map(|e| {
             if app.preview_is_diff {
                 format!("{} [diff]", e.name)
+            } else if app.meta_preview_mode {
+                format!("{} [meta]", e.name)
             } else {
                 e.name.clone()
             }
@@ -1204,6 +1250,8 @@ fn draw_help_overlay(f: &mut Frame, size: Rect) {
         // ── View ────────────────────────────────────────────────────────────
         section_header("View"),
         key_line("d", "Toggle git diff preview"),
+        key_line("m", "Toggle file metadata view"),
+        key_line("P", "Edit file permissions (chmod)"),
         key_line("R", "Refresh git status"),
         key_line("S", "Cycle sort: Name/Size/Modified/Ext"),
         key_line("s", "Toggle sort order ↑↓"),


### PR DESCRIPTION
## Summary

- `m` toggles the preview pane to a structured metadata card: path, type, size (human + raw bytes), Unix mode (symbolic + octal), UID/GID, modified, accessed; pane title shows `filename [meta]`; mutually exclusive with diff mode
- `P` opens an inline chmod editor showing the current octal mode; restricted to digits 0–7 (max 4 chars); `Enter` applies, `Esc` cancels; meta card refreshes on success
- Both documented in the help overlay under View
- `format_unix_timestamp_utc`: pure Rust UTC arithmetic, no subprocess, no new deps

## Test plan

- [ ] 6 new unit tests: `rw-r--r--` (0644), `rwxr-xr-x` (0755), 0 B, 1.0 KB, epoch timestamp, known date timestamp — all pass
- [ ] `cargo clippy -- -D warnings` clean; `cargo build --release` succeeds
- [ ] Manual: select a file, press `m` → metadata card appears; navigate to another file → metadata updates; press `m` again → returns to content view
- [ ] Manual: press `P` → input bar shows current mode; type `755`, Enter → `Mode set to 0755`; `m` shows updated mode
- [ ] Manual: press `d` while in meta view → exits meta view, shows diff

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)