### PR TITLE
feat: filter/narrow mode (|) — in-place listing narrowing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.0] - 2026-03-24
+
+### Added
+- **`|` — filter/narrow mode**: opens an inline filter bar at the bottom; as the user types, the current directory listing narrows in real time to entries whose names contain the query (case-insensitive substring match)
+- **`Enter` or `|` (in filter bar)**: closes the bar but keeps the filter active ("frozen"); the current pane title shows `dirname [~pattern]` to signal the active filter
+- **`Esc` (in filter bar)**: clears the filter and closes the bar in one step, restoring the full listing
+- **`Esc` (in normal mode, when a filter is active)**: clears the filter and restores the full listing; if no filter is active, clears selections as before
+- Filter is automatically re-applied after every `load_dir` call (trash, paste, mkdir, sort change, hidden-files toggle), keeping the narrowed set coherent across file operations
+- Navigating into a subdirectory, going to parent, going home, jumping via bookmark/find, or using history back/forward clears the filter (scoped to the current directory)
+- `|` documented in the help overlay (`?`) under Search
+- 8 new unit tests covering default state, start/close/clear, case-insensitive narrowing, pop-char widening, empty-match, and full-listing restoration
+
 ## [0.15.0] - 2026-03-24
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -586,7 +586,7 @@ dependencies = [
 
 [[package]]
 name = "trek"
-version = "0.11.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trek"
-version = "0.15.0"
+version = "0.16.0"
 edition = "2021"
 rust-version = "1.80"
 description = "A terminal file manager with mouse-resizable panes"

--- a/src/app.rs
+++ b/src/app.rs
@@ -233,6 +233,13 @@ pub struct App {
     history: Vec<HistoryEntry>,
     /// Index into `history` pointing at the current location.
     history_pos: usize,
+
+    // --- Filter / narrow mode (|) ---
+    /// True while the filter input bar is open (user is actively typing).
+    pub filter_mode: bool,
+    /// Active filter string. Empty = no filter. Non-empty while filter_mode is false
+    /// means the filter is "frozen" (bar closed, listing still narrowed).
+    pub filter_input: String,
 }
 
 #[derive(Clone)]
@@ -322,6 +329,8 @@ impl App {
                 selected: 0,
             }],
             history_pos: 0,
+            filter_mode: false,
+            filter_input: String::new(),
         };
         app.load_dir();
         Ok(app)
@@ -343,6 +352,14 @@ impl App {
                 self.status_message = Some(format!("Cannot read directory: {e}"));
             }
         }
+
+        // Re-apply active filter to the freshly loaded entries.
+        if !self.filter_input.is_empty() {
+            let pattern = self.filter_input.to_lowercase();
+            self.entries
+                .retain(|e| e.name.to_lowercase().contains(&pattern));
+        }
+
         if self.selected >= self.entries.len() {
             self.selected = self.entries.len().saturating_sub(1);
         }
@@ -835,6 +852,8 @@ impl App {
                 .cwd
                 .file_name()
                 .map(|n| n.to_string_lossy().into_owned());
+            self.filter_input.clear();
+            self.filter_mode = false;
             self.push_history(parent.clone());
             self.cwd = parent;
             self.load_dir();
@@ -851,6 +870,8 @@ impl App {
     pub fn enter_selected(&mut self) {
         if let Some(entry) = self.entries.get(self.selected).cloned() {
             if entry.is_dir {
+                self.filter_input.clear();
+                self.filter_mode = false;
                 self.push_history(entry.path.clone());
                 self.cwd = entry.path;
                 self.selected = 0;
@@ -865,6 +886,8 @@ impl App {
 
     pub fn go_home(&mut self) {
         if let Some(home) = dirs_home() {
+            self.filter_input.clear();
+            self.filter_mode = false;
             self.push_history(home.clone());
             self.cwd = home;
             self.selected = 0;
@@ -910,6 +933,8 @@ impl App {
         if let Some(e) = self.history.get_mut(self.history_pos) {
             e.selected = self.selected;
         }
+        self.filter_input.clear();
+        self.filter_mode = false;
         self.history_pos -= 1;
         self.restore_history_entry();
     }
@@ -923,6 +948,8 @@ impl App {
         if let Some(e) = self.history.get_mut(self.history_pos) {
             e.selected = self.selected;
         }
+        self.filter_input.clear();
+        self.filter_mode = false;
         self.history_pos += 1;
         self.restore_history_entry();
     }
@@ -1656,6 +1683,8 @@ impl App {
             self.status_message = Some(format!("\"{}\" no longer exists", dest.display()));
             return;
         }
+        self.filter_input.clear();
+        self.filter_mode = false;
         self.push_history(dest.clone());
         self.cwd = dest;
         self.selected = 0;
@@ -1799,6 +1828,9 @@ impl App {
             return;
         };
 
+        self.filter_input.clear();
+        self.filter_mode = false;
+
         if parent != self.cwd {
             let new_dir = parent.to_path_buf();
             self.push_history(new_dir.clone());
@@ -1849,6 +1881,42 @@ impl App {
         let seq = format!("\x1b]52;c;{}\x07", encoded);
         let _ = std::io::stdout().write_all(seq.as_bytes());
         let _ = std::io::stdout().flush();
+    }
+
+    // --- Filter / narrow mode (|) ---
+
+    /// Open the filter input bar.
+    pub fn start_filter(&mut self) {
+        self.filter_mode = true;
+    }
+
+    /// Close the bar but keep the filter active ("frozen" state).
+    pub fn close_filter(&mut self) {
+        self.filter_mode = false;
+    }
+
+    /// Clear the active filter and restore the full listing.
+    pub fn clear_filter(&mut self) {
+        self.filter_input.clear();
+        self.filter_mode = false;
+        self.current_scroll = 0;
+        self.load_dir();
+    }
+
+    /// Add a character to the filter and re-narrow the listing.
+    pub fn filter_push_char(&mut self, c: char) {
+        self.filter_input.push(c);
+        self.selected = 0;
+        self.current_scroll = 0;
+        self.load_dir();
+    }
+
+    /// Remove the last character from the filter and reload.
+    pub fn filter_pop_char(&mut self) {
+        self.filter_input.pop();
+        self.selected = 0;
+        self.current_scroll = 0;
+        self.load_dir();
     }
 
     // --- Metadata preview (m) ---
@@ -2396,5 +2464,194 @@ mod tests {
             format_unix_timestamp_utc(1_705_318_245),
             "2024-01-15 11:30:45"
         );
+    }
+
+    // ── Filter / narrow mode tests ────────────────────────────────────────────
+
+    /// Given: a fresh App
+    /// When: filter state is inspected
+    /// Then: filter_mode is false and filter_input is empty
+    #[test]
+    fn filter_mode_is_off_by_default() {
+        let dir = std::env::temp_dir();
+        let app = make_app_at(&dir);
+        assert!(!app.filter_mode);
+        assert!(app.filter_input.is_empty());
+    }
+
+    /// Given: a fresh App
+    /// When: start_filter() is called
+    /// Then: filter_mode is true
+    #[test]
+    fn start_filter_sets_filter_mode() {
+        let dir = std::env::temp_dir();
+        let mut app = make_app_at(&dir);
+        app.start_filter();
+        assert!(app.filter_mode);
+    }
+
+    /// Given: an App in a temp dir containing "alpha.txt" and "beta.txt"
+    /// When: filter_push_char('a') is called
+    /// Then: only entries whose names contain 'a' remain
+    #[test]
+    fn filter_push_char_narrows_listing() {
+        let tmp =
+            std::env::temp_dir().join(format!("trek_filter_test_narrow_{}", std::process::id()));
+        let _ = std::fs::create_dir_all(&tmp);
+        std::fs::write(tmp.join("alpha.txt"), b"").unwrap();
+        std::fs::write(tmp.join("beta.txt"), b"").unwrap();
+        std::fs::write(tmp.join("gamma.txt"), b"").unwrap();
+
+        let mut app = make_app_at(&tmp);
+        app.start_filter();
+        app.filter_push_char('a');
+
+        let names: Vec<&str> = app.entries.iter().map(|e| e.name.as_str()).collect();
+        // "alpha" and "beta" contain 'a'; "gamma" contains 'a' too
+        // none should contain entries that don't match
+        for name in &names {
+            assert!(
+                name.to_lowercase().contains('a'),
+                "expected all entries to contain 'a', got {name}"
+            );
+        }
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    /// Given: a file named "README.md"
+    /// When: filter_push_char with lowercase 'r', 'e', 'a' is called
+    /// Then: the file still appears (case-insensitive match)
+    #[test]
+    fn filter_is_case_insensitive() {
+        let tmp =
+            std::env::temp_dir().join(format!("trek_filter_test_case_{}", std::process::id()));
+        let _ = std::fs::create_dir_all(&tmp);
+        std::fs::write(tmp.join("README.md"), b"").unwrap();
+        std::fs::write(tmp.join("other.txt"), b"").unwrap();
+
+        let mut app = make_app_at(&tmp);
+        app.start_filter();
+        app.filter_push_char('r');
+        app.filter_push_char('e');
+        app.filter_push_char('a');
+
+        assert!(
+            app.entries.iter().any(|e| e.name == "README.md"),
+            "README.md should still be visible with filter 'rea'"
+        );
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    /// Given: filter "al" is active (showing only "alpha.txt")
+    /// When: filter_pop_char() is called
+    /// Then: listing contains more entries than before (filter widened)
+    #[test]
+    fn filter_pop_char_widens_listing() {
+        let tmp = std::env::temp_dir().join(format!("trek_filter_test_pop_{}", std::process::id()));
+        let _ = std::fs::create_dir_all(&tmp);
+        std::fs::write(tmp.join("alpha.txt"), b"").unwrap();
+        std::fs::write(tmp.join("beta.txt"), b"").unwrap();
+
+        let mut app = make_app_at(&tmp);
+        app.start_filter();
+        app.filter_push_char('a');
+        app.filter_push_char('l');
+        let narrow_count = app.entries.len();
+
+        app.filter_pop_char(); // back to just "a"
+        let wider_count = app.entries.len();
+        assert!(
+            wider_count >= narrow_count,
+            "popping a char should not shrink the listing further"
+        );
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    /// Given: filter "xyz" matches nothing
+    /// When: filter_push_char cycles build "xyz"
+    /// Then: entries is empty and no panic occurs
+    #[test]
+    fn filter_no_match_gives_empty_listing() {
+        let tmp =
+            std::env::temp_dir().join(format!("trek_filter_test_empty_{}", std::process::id()));
+        let _ = std::fs::create_dir_all(&tmp);
+        std::fs::write(tmp.join("alpha.txt"), b"").unwrap();
+
+        let mut app = make_app_at(&tmp);
+        app.start_filter();
+        for c in "zzznomatch".chars() {
+            app.filter_push_char(c);
+        }
+        // Should be empty, not panic
+        assert_eq!(app.entries.len(), 0);
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    /// Given: filter_mode is true with non-empty filter_input
+    /// When: close_filter() is called
+    /// Then: filter_mode is false but filter_input is still non-empty (frozen)
+    #[test]
+    fn close_filter_keeps_filter_active() {
+        let tmp =
+            std::env::temp_dir().join(format!("trek_filter_test_close_{}", std::process::id()));
+        let _ = std::fs::create_dir_all(&tmp);
+        std::fs::write(tmp.join("alpha.txt"), b"").unwrap();
+
+        let mut app = make_app_at(&tmp);
+        app.start_filter();
+        app.filter_push_char('a');
+        app.close_filter();
+
+        assert!(
+            !app.filter_mode,
+            "filter_mode should be false after close_filter"
+        );
+        assert!(
+            !app.filter_input.is_empty(),
+            "filter_input should remain non-empty"
+        );
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    /// Given: a frozen filter narrowing the listing
+    /// When: clear_filter() is called
+    /// Then: filter_input is empty, filter_mode is false, full listing is restored
+    #[test]
+    fn clear_filter_restores_full_listing() {
+        let tmp =
+            std::env::temp_dir().join(format!("trek_filter_test_clear_{}", std::process::id()));
+        let _ = std::fs::create_dir_all(&tmp);
+        std::fs::write(tmp.join("alpha.txt"), b"").unwrap();
+        std::fs::write(tmp.join("zzz.txt"), b"").unwrap(); // no 'a' in stem
+
+        let mut app = make_app_at(&tmp);
+        let full_count = app.entries.len();
+
+        // "alp" matches only "alpha.txt", not "zzz.txt"
+        app.start_filter();
+        app.filter_push_char('a');
+        app.filter_push_char('l');
+        app.filter_push_char('p');
+        let narrow_count = app.entries.len();
+        assert!(
+            narrow_count < full_count,
+            "filter 'alp' should narrow the listing (full={full_count}, narrow={narrow_count})"
+        );
+
+        app.clear_filter();
+        assert!(app.filter_input.is_empty());
+        assert!(!app.filter_mode);
+        assert_eq!(
+            app.entries.len(),
+            full_count,
+            "full listing should be restored"
+        );
+
+        let _ = std::fs::remove_dir_all(&tmp);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -363,6 +363,15 @@ fn run(
                         KeyCode::Char(c @ '0'..='7') => app.chmod_push_char(c),
                         _ => {}
                     }
+                } else if app.filter_mode {
+                    match key.code {
+                        KeyCode::Esc => app.clear_filter(),
+                        KeyCode::Enter => app.close_filter(),
+                        KeyCode::Char('|') => app.close_filter(),
+                        KeyCode::Backspace => app.filter_pop_char(),
+                        KeyCode::Char(c) => app.filter_push_char(c),
+                        _ => {}
+                    }
                 } else if app.search_mode {
                     match key.code {
                         KeyCode::Esc => app.cancel_search(),
@@ -393,6 +402,7 @@ fn run(
                         KeyCode::Char('~') => app.go_home(),
                         KeyCode::Char('.') => app.toggle_hidden(),
                         KeyCode::Char('/') => app.start_search(),
+                        KeyCode::Char('|') => app.start_filter(),
                         KeyCode::Char('y') => app.yank_relative_path(),
                         KeyCode::Char('Y') => app.yank_absolute_path(),
                         KeyCode::Char('d') => app.toggle_diff_preview(),
@@ -404,7 +414,13 @@ fn run(
                         KeyCode::Char(' ') => app.toggle_selection(app.selected),
                         KeyCode::Char('v') => app.select_all(),
                         KeyCode::Char('r') => app.start_rename(),
-                        KeyCode::Esc => app.clear_selections(),
+                        KeyCode::Esc => {
+                            if !app.filter_input.is_empty() {
+                                app.clear_filter();
+                            } else {
+                                app.clear_selections();
+                            }
+                        }
                         // File operations
                         KeyCode::Char('c') => app.clipboard_copy_current(),
                         KeyCode::Char('C') => app.clipboard_copy_selected(),

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -105,6 +105,8 @@ pub fn draw(f: &mut Frame, app: &mut App) {
         draw_content_search_bar(f, app, bottom_area);
     } else if app.find_mode {
         draw_find_bar(f, app, bottom_area);
+    } else if app.filter_mode {
+        draw_filter_bar(f, app, bottom_area);
     } else if app.search_mode {
         draw_search_bar(f, app, bottom_area);
     } else if let Some(ref msg) = app.status_message {
@@ -251,6 +253,27 @@ fn draw_search_bar(f: &mut Frame, app: &App, area: Rect) {
     f.render_widget(para, area);
 }
 
+fn draw_filter_bar(f: &mut Frame, app: &App, area: Rect) {
+    let para = Paragraph::new(Line::from(vec![
+        Span::styled(
+            " Filter: ",
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(
+            format!("{}_", app.filter_input),
+            Style::default().fg(Color::White),
+        ),
+        Span::styled(
+            "  Esc=clear  Enter=freeze",
+            Style::default().fg(Color::DarkGray),
+        ),
+    ]))
+    .block(Block::default().borders(Borders::TOP));
+    f.render_widget(para, area);
+}
+
 fn draw_delete_confirm_bar(f: &mut Frame, app: &App, area: Rect) {
     let count = app.pending_delete.len();
     let subject = if count == 1 {
@@ -390,11 +413,18 @@ fn draw_parent_pane(f: &mut Frame, app: &App, area: Rect) {
 }
 
 fn draw_current_pane(f: &mut Frame, app: &App, area: Rect) {
-    let title = app
+    let base_title = app
         .cwd
         .file_name()
         .map(|n| n.to_string_lossy().into_owned())
         .unwrap_or_else(|| app.cwd.to_string_lossy().into_owned());
+
+    // Show [~pattern] when filter is frozen (active but bar is closed).
+    let title = if !app.filter_input.is_empty() && !app.filter_mode {
+        format!("{} [~{}]", base_title, app.filter_input)
+    } else {
+        base_title
+    };
 
     let is_searching = app.search_mode && !app.search_query.is_empty();
     // 2-char prefix always reserved so layout doesn't shift when selection changes.
@@ -1242,6 +1272,7 @@ fn draw_help_overlay(f: &mut Frame, size: Rect) {
         // ── Search ──────────────────────────────────────────────────────────
         section_header("Search"),
         key_line("/", "Fuzzy search"),
+        key_line("|", "Filter/narrow listing (case-insensitive)"),
         key_line("Ctrl+F", "Content search (ripgrep)"),
         key_line("Ctrl+P", "Recursive filename find"),
         key_line("b", "Bookmark current directory"),
@@ -1261,7 +1292,7 @@ fn draw_help_overlay(f: &mut Frame, size: Rect) {
         key_line("Space", "Toggle file selection"),
         key_line("v", "Select all files"),
         key_line("r", "Rename selected files"),
-        key_line("Esc", "Clear selections / cancel mode"),
+        key_line("Esc", "Clear filter (if active) or selections"),
         Line::from(""),
         // ── File Operations ─────────────────────────────────────────────────
         section_header("File Operations"),


### PR DESCRIPTION
## Summary

- Adds `|` keybinding to open a filter input bar that narrows the current directory listing in real time (case-insensitive substring match)
- `Enter` or `|` freezes the filter (bar closes, pane title shows `dirname [~pattern]`)
- `Esc` in filter bar or normal mode (when filter active) clears the filter and restores the full listing
- Filter is re-applied after every `load_dir` call — file operations work on the filtered set
- Navigation away from the current directory clears the filter automatically
- `|` documented in the help overlay under Search

## Test plan

- [x] 8 new unit tests: default state, start/close/clear, case-insensitive narrowing, pop-char widening, no-match empty listing, full-listing restoration
- [x] `cargo fmt` clean
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo build --release` succeeds
- [x] `cargo test` — 96 tests pass

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)