### PR TITLE
feat(nav): open files in external editor / system default (o / O)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.0] - 2026-03-24
+
+### Added
+- **`o` — open in terminal editor**: pressing `o` on a file tears down the TUI, launches `$VISUAL` → `$EDITOR` → `vi` (fallback) with the file path, then restores the TUI on exit; status bar shows `Returned from <editor>`; `app.load_dir()` is called on return to pick up filesystem changes; `o` on a directory is a no-op
+- **`O` — open with system default**: spawns `open` (macOS) or `xdg-open` (Linux) in the background; Trek stays running; status bar shows `Opening <name> with system default…`; descriptive error shown if the opener is not available
+- TUI is always restored after `o` even if the editor command fails to start (unconditional `enable_raw_mode` + `EnterAlternateScreen` outside the status match)
+- Both bindings documented in the help overlay (`?`) under File Operations and in `--help` output
+- 5 new unit tests covering `selected_file_path` (empty entries, directory no-op, file returns path) and `selected_path` (directory and file variants)
+
 ## [0.16.1] - 2026-03-24
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -586,7 +586,7 @@ dependencies = [
 
 [[package]]
 name = "trek"
-version = "0.16.1"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trek"
-version = "0.16.1"
+version = "0.17.0"
 edition = "2021"
 rust-version = "1.80"
 description = "A terminal file manager with mouse-resizable panes"

--- a/src/app/navigation.rs
+++ b/src/app/navigation.rs
@@ -216,4 +216,19 @@ impl App {
     pub fn history_position(&self) -> usize {
         self.history_pos
     }
+
+    /// Returns the path of the currently selected file (not directory), or None.
+    /// Used by the open-in-editor (`o`) handler which should not act on directories.
+    pub fn selected_file_path(&self) -> Option<PathBuf> {
+        self.entries
+            .get(self.selected)
+            .filter(|e| !e.is_dir)
+            .map(|e| e.path.clone())
+    }
+
+    /// Returns the path of the currently selected entry (file or directory).
+    /// Used by the open-with-system-default (`O`) handler.
+    pub fn selected_path(&self) -> Option<PathBuf> {
+        self.entries.get(self.selected).map(|e| e.path.clone())
+    }
 }

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -471,3 +471,93 @@ fn clear_filter_restores_full_listing() {
 
     let _ = std::fs::remove_dir_all(&tmp);
 }
+
+// ── open-in-external tests ───────────────────────────────────────────────────
+
+/// Given: no entries in the listing
+/// When: selected_file_path() is called
+/// Then: returns None
+#[test]
+fn selected_file_path_empty_entries_returns_none() {
+    let tmp = std::env::temp_dir().join(format!("trek_open_empty_{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&tmp);
+    let mut app = make_app_at(&tmp);
+    app.entries.clear();
+    assert!(app.selected_file_path().is_none());
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+/// Given: selected entry is a directory
+/// When: selected_file_path() is called
+/// Then: returns None (directories are not files)
+#[test]
+fn selected_file_path_on_directory_returns_none() {
+    let tmp = std::env::temp_dir().join(format!("trek_open_dir_{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&tmp);
+    let sub = tmp.join("subdir");
+    let _ = std::fs::create_dir_all(&sub);
+
+    let mut app = make_app_at(&tmp);
+    if let Some(idx) = app.entries.iter().position(|e| e.is_dir) {
+        app.selected = idx;
+    }
+    assert!(app.selected_file_path().is_none());
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+/// Given: selected entry is a regular file
+/// When: selected_file_path() is called
+/// Then: returns Some(path) pointing to that file
+#[test]
+fn selected_file_path_on_file_returns_some() {
+    let tmp = std::env::temp_dir().join(format!("trek_open_file_{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&tmp);
+    std::fs::write(tmp.join("readme.md"), b"hello").unwrap();
+
+    let mut app = make_app_at(&tmp);
+    if let Some(idx) = app.entries.iter().position(|e| !e.is_dir) {
+        app.selected = idx;
+        let path = app.selected_file_path();
+        assert!(path.is_some());
+        assert_eq!(
+            path.unwrap().file_name().unwrap().to_string_lossy(),
+            "readme.md"
+        );
+    }
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+/// Given: selected entry is a directory
+/// When: selected_path() is called
+/// Then: returns Some(path) (selected_path works for both files and dirs)
+#[test]
+fn selected_path_on_directory_returns_some() {
+    let tmp = std::env::temp_dir().join(format!("trek_selpath_dir_{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&tmp);
+    let sub = tmp.join("subdir");
+    let _ = std::fs::create_dir_all(&sub);
+
+    let mut app = make_app_at(&tmp);
+    if let Some(idx) = app.entries.iter().position(|e| e.is_dir) {
+        app.selected = idx;
+    }
+    assert!(app.selected_path().is_some());
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+/// Given: selected entry is a file
+/// When: selected_path() is called
+/// Then: returns Some(path)
+#[test]
+fn selected_path_on_file_returns_some() {
+    let tmp = std::env::temp_dir().join(format!("trek_selpath_file_{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&tmp);
+    std::fs::write(tmp.join("config.toml"), b"[tool]").unwrap();
+
+    let mut app = make_app_at(&tmp);
+    if let Some(idx) = app.entries.iter().position(|e| !e.is_dir) {
+        app.selected = idx;
+    }
+    assert!(app.selected_path().is_some());
+    let _ = std::fs::remove_dir_all(&tmp);
+}

--- a/src/args.rs
+++ b/src/args.rs
@@ -78,6 +78,7 @@ pub fn print_help() {
     println!("    d           Toggle diff preview R           Refresh git status");
     println!("    Space       Toggle file selection v          Select all files");
     println!("    r           Rename selected files Esc        Clear selections");
+    println!("    o           Open in $EDITOR        O           Open with system default");
     println!("    c           Copy current to clipboard C          Copy selected to clipboard");
     println!("    x           Cut current to clipboard");
     println!("    p           Paste clipboard       Delete      Delete current file/dir");

--- a/src/events.rs
+++ b/src/events.rs
@@ -1,9 +1,12 @@
 use crate::app::App;
 use anyhow::Result;
 use crossterm::{
-    event::{self, DisableMouseCapture, Event, KeyCode, KeyModifiers, MouseButton, MouseEventKind},
+    event::{
+        self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyModifiers, MouseButton,
+        MouseEventKind,
+    },
     execute,
-    terminal::{disable_raw_mode, LeaveAlternateScreen},
+    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
 use ratatui::{backend::CrosstermBackend, Terminal};
 use std::io;
@@ -190,6 +193,69 @@ pub fn run(
                         }
                         KeyCode::Char('i') if key.modifiers.contains(KeyModifiers::CONTROL) => {
                             app.history_forward()
+                        }
+                        // Open in terminal editor ($VISUAL → $EDITOR → vi)
+                        KeyCode::Char('o') => {
+                            if let Some(path) = app.selected_file_path() {
+                                let editor = std::env::var("VISUAL")
+                                    .or_else(|_| std::env::var("EDITOR"))
+                                    .unwrap_or_else(|_| "vi".to_string());
+
+                                // Tear down TUI so the editor owns the terminal.
+                                disable_raw_mode()?;
+                                execute!(io::stdout(), LeaveAlternateScreen, DisableMouseCapture)?;
+
+                                let status =
+                                    std::process::Command::new(&editor).arg(&path).status();
+
+                                // Always restore the TUI, even if the editor failed.
+                                enable_raw_mode()?;
+                                execute!(io::stdout(), EnterAlternateScreen, EnableMouseCapture)?;
+                                terminal.clear()?;
+
+                                // Refresh listing in case the editor created/deleted files.
+                                app.load_dir();
+
+                                match status {
+                                    Ok(_) => {
+                                        app.status_message =
+                                            Some(format!("Returned from {}", editor))
+                                    }
+                                    Err(e) => {
+                                        app.status_message = Some(format!(
+                                            "Failed to open editor '{}': {}",
+                                            editor, e
+                                        ))
+                                    }
+                                }
+                            }
+                        }
+                        // Open with system default (open on macOS, xdg-open on Linux)
+                        KeyCode::Char('O') => {
+                            if let Some(path) = app.selected_path() {
+                                let name = path
+                                    .file_name()
+                                    .map(|n| n.to_string_lossy().into_owned())
+                                    .unwrap_or_else(|| path.to_string_lossy().into_owned());
+
+                                #[cfg(target_os = "macos")]
+                                let opener = "open";
+                                #[cfg(not(target_os = "macos"))]
+                                let opener = "xdg-open";
+
+                                match std::process::Command::new(opener).arg(&path).spawn() {
+                                    Ok(_) => {
+                                        app.status_message = Some(format!(
+                                            "Opening {} with system default\u{2026}",
+                                            name
+                                        ))
+                                    }
+                                    Err(e) => {
+                                        app.status_message =
+                                            Some(format!("Failed to open '{}': {}", name, e))
+                                    }
+                                }
+                            }
                         }
                         _ => {}
                     }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1248,7 +1248,7 @@ fn draw_find_bar(f: &mut Frame, app: &App, area: Rect) {
 
 fn draw_help_overlay(f: &mut Frame, size: Rect) {
     let width = 60u16.min(size.width.saturating_sub(4));
-    let height = 46u16.min(size.height.saturating_sub(4));
+    let height = 48u16.min(size.height.saturating_sub(4));
     let x = (size.width.saturating_sub(width)) / 2;
     let y = (size.height.saturating_sub(height)) / 2;
     let area = Rect::new(x, y, width, height);
@@ -1296,6 +1296,8 @@ fn draw_help_overlay(f: &mut Frame, size: Rect) {
         Line::from(""),
         // ── File Operations ─────────────────────────────────────────────────
         section_header("File Operations"),
+        key_line("o", "Open in $EDITOR (suspends TUI)"),
+        key_line("O", "Open with system default (background)"),
         key_line("c / C", "Copy current / selected"),
         key_line("x", "Cut current to clipboard"),
         key_line("p", "Paste clipboard into current dir"),


### PR DESCRIPTION
## Summary
- `o` — tears down the TUI, launches `$VISUAL` → `$EDITOR` → `vi` (fallback) with the selected file; restores TUI unconditionally when the editor exits; refreshes listing via `load_dir()`; no-op on directories
- `O` — spawns `open` (macOS) / `xdg-open` (Linux) in the background; Trek stays running; shows status message with filename
- TUI is always restored after `o` even if the editor fails to start (enable_raw_mode + EnterAlternateScreen unconditional)
- Both bindings documented in help overlay (`?`) and `--help` output
- 5 new unit tests for `selected_file_path` and `selected_path` helper methods

Closes #28

## Acceptance criteria
- [x] `o` on a file launches `$VISUAL` → `$EDITOR` → `vi` fallback
- [x] Trek exits TUI before editor launches; editor has full terminal access
- [x] TUI re-enters and repaints correctly when editor exits
- [x] `app.load_dir()` called after editor exits
- [x] Status bar shows `Returned from <editor>` on success
- [x] Descriptive error shown if editor fails to start
- [x] `o` on a directory is a no-op
- [x] `O` spawns system opener asynchronously; Trek stays running
- [x] Status bar shows `Opening <name> with system default…`
- [x] Both bindings in help overlay and `--help`

## Test plan
- [x] `cargo test` — 101 passed, 0 failed
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt` — applied
- [x] `cargo build --release` — compiles as v0.17.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)