### PR TITLE
feat(nav): command palette (:) — searchable action registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.18.0] - 2026-03-24
+
+### Added
+- **`:` — command palette**: opens a centered searchable overlay listing all ~34 Trek actions with their keybinding hints; typing narrows the list with case-insensitive substring matching; `Enter`/`l` executes the highlighted action and closes the palette; `Esc`/`:` closes without executing; `j`/`k` and `Up`/`Down` navigate the list
+- Empty query shows all actions; no-match query shows `"No matching actions"`; `Quit` appears for discoverability but is a no-op (use `q` directly)
+- New `src/app/palette.rs` module: `ActionId` enum (34 variants), `PaletteAction` struct, `PALETTE_ACTIONS` static registry, `filter_palette()` function
+- New `src/app/palette_ops.rs`: `open_palette`, `close_palette`, `palette_push_char`, `palette_pop_char`, `palette_move_up`, `palette_move_down`, `palette_selected_action`
+- `execute_palette_action()` in `src/events.rs` dispatches all 34 action IDs; owns the terminal handle for future actions requiring TUI teardown
+- `:` documented in help overlay (`?`) and `--help` output
+- 9 new unit tests: filter empty/substring/no-match, open/close, push/pop char, navigation bounds, selected action ID
+
 ## [0.17.0] - 2026-03-24
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -586,7 +586,7 @@ dependencies = [
 
 [[package]]
 name = "trek"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trek"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 rust-version = "1.80"
 description = "A terminal file manager with mouse-resizable panes"

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -17,6 +17,8 @@ mod layout;
 mod metadata;
 mod mouse;
 mod navigation;
+pub mod palette;
+mod palette_ops;
 mod preview;
 mod rename;
 mod search;
@@ -252,6 +254,16 @@ pub struct App {
     /// Active filter string. Empty = no filter. Non-empty while filter_mode is false
     /// means the filter is "frozen" (bar closed, listing still narrowed).
     pub filter_input: String,
+
+    // --- Command palette (:) ---
+    /// True when the command palette overlay is open.
+    pub palette_mode: bool,
+    /// The text the user has typed into the palette search bar.
+    pub palette_query: String,
+    /// Index within `palette_filtered` of the highlighted row.
+    pub palette_selected: usize,
+    /// Indices into `palette::PALETTE_ACTIONS` matching the current query.
+    pub palette_filtered: Vec<usize>,
 }
 
 #[derive(Clone)]
@@ -343,6 +355,10 @@ impl App {
             history_pos: 0,
             filter_mode: false,
             filter_input: String::new(),
+            palette_mode: false,
+            palette_query: String::new(),
+            palette_selected: 0,
+            palette_filtered: palette::filter_palette(""),
         };
         app.load_dir();
         Ok(app)

--- a/src/app/palette.rs
+++ b/src/app/palette.rs
@@ -1,0 +1,240 @@
+/// Command palette action registry.
+///
+/// Every Trek command is registered here with a human-readable name and
+/// keybinding hint. When adding a new feature, add a corresponding entry to
+/// PALETTE_ACTIONS so it is discoverable from the palette.
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ActionId {
+    GoHome,
+    GoTop,
+    GoBottom,
+    HistoryBack,
+    HistoryForward,
+    ToggleHidden,
+    ToggleDiffPreview,
+    ToggleMetaPreview,
+    RefreshGitStatus,
+    StartSearch,
+    StartFilter,
+    StartContentSearch,
+    StartFind,
+    ClipboardCopyCurrent,
+    ClipboardCopySelected,
+    ClipboardCutCurrent,
+    PasteClipboard,
+    BeginDeleteCurrent,
+    BeginDeleteSelected,
+    BeginMkdir,
+    UndoTrash,
+    BeginChmod,
+    ToggleSelection,
+    SelectAll,
+    ClearSelections,
+    StartRename,
+    AddBookmark,
+    OpenBookmarks,
+    CycleSortMode,
+    ToggleSortOrder,
+    YankRelativePath,
+    YankAbsolutePath,
+    ShowHelp,
+    Quit,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct PaletteAction {
+    pub id: ActionId,
+    /// Searched when filtering — full English description.
+    pub name: &'static str,
+    /// Displayed alongside the action name in the overlay.
+    pub keys: &'static str,
+}
+
+pub static PALETTE_ACTIONS: &[PaletteAction] = &[
+    PaletteAction {
+        id: ActionId::GoHome,
+        name: "Go to home directory",
+        keys: "~",
+    },
+    PaletteAction {
+        id: ActionId::GoTop,
+        name: "Go to top of list",
+        keys: "g",
+    },
+    PaletteAction {
+        id: ActionId::GoBottom,
+        name: "Go to bottom of list",
+        keys: "G",
+    },
+    PaletteAction {
+        id: ActionId::HistoryBack,
+        name: "Go back in history",
+        keys: "Ctrl+O",
+    },
+    PaletteAction {
+        id: ActionId::HistoryForward,
+        name: "Go forward in history",
+        keys: "Ctrl+I",
+    },
+    PaletteAction {
+        id: ActionId::ToggleHidden,
+        name: "Toggle hidden files",
+        keys: ".",
+    },
+    PaletteAction {
+        id: ActionId::ToggleDiffPreview,
+        name: "Toggle diff preview",
+        keys: "d",
+    },
+    PaletteAction {
+        id: ActionId::ToggleMetaPreview,
+        name: "Toggle meta preview (permissions, size)",
+        keys: "m",
+    },
+    PaletteAction {
+        id: ActionId::RefreshGitStatus,
+        name: "Refresh git status",
+        keys: "R",
+    },
+    PaletteAction {
+        id: ActionId::StartSearch,
+        name: "Fuzzy search",
+        keys: "/",
+    },
+    PaletteAction {
+        id: ActionId::StartFilter,
+        name: "Filter / narrow listing",
+        keys: "|",
+    },
+    PaletteAction {
+        id: ActionId::StartContentSearch,
+        name: "Content search (ripgrep)",
+        keys: "Ctrl+F",
+    },
+    PaletteAction {
+        id: ActionId::StartFind,
+        name: "Recursive filename find",
+        keys: "Ctrl+P",
+    },
+    PaletteAction {
+        id: ActionId::ClipboardCopyCurrent,
+        name: "Copy current file to clipboard",
+        keys: "c",
+    },
+    PaletteAction {
+        id: ActionId::ClipboardCopySelected,
+        name: "Copy selected files to clipboard",
+        keys: "C",
+    },
+    PaletteAction {
+        id: ActionId::ClipboardCutCurrent,
+        name: "Cut current file to clipboard",
+        keys: "x",
+    },
+    PaletteAction {
+        id: ActionId::PasteClipboard,
+        name: "Paste clipboard into current directory",
+        keys: "p",
+    },
+    PaletteAction {
+        id: ActionId::BeginDeleteCurrent,
+        name: "Trash current file or directory",
+        keys: "Delete",
+    },
+    PaletteAction {
+        id: ActionId::BeginDeleteSelected,
+        name: "Trash all selected files",
+        keys: "X",
+    },
+    PaletteAction {
+        id: ActionId::BeginMkdir,
+        name: "New directory",
+        keys: "M",
+    },
+    PaletteAction {
+        id: ActionId::UndoTrash,
+        name: "Undo last trash operation",
+        keys: "u",
+    },
+    PaletteAction {
+        id: ActionId::BeginChmod,
+        name: "chmod — edit file permissions",
+        keys: "P",
+    },
+    PaletteAction {
+        id: ActionId::ToggleSelection,
+        name: "Toggle file selection",
+        keys: "Space",
+    },
+    PaletteAction {
+        id: ActionId::SelectAll,
+        name: "Select all files",
+        keys: "v",
+    },
+    PaletteAction {
+        id: ActionId::ClearSelections,
+        name: "Clear selections",
+        keys: "Esc",
+    },
+    PaletteAction {
+        id: ActionId::StartRename,
+        name: "Bulk rename with regex",
+        keys: "r",
+    },
+    PaletteAction {
+        id: ActionId::AddBookmark,
+        name: "Add bookmark for current directory",
+        keys: "b",
+    },
+    PaletteAction {
+        id: ActionId::OpenBookmarks,
+        name: "Open bookmark picker",
+        keys: "B",
+    },
+    PaletteAction {
+        id: ActionId::CycleSortMode,
+        name: "Cycle sort mode (name/size/modified/ext)",
+        keys: "S",
+    },
+    PaletteAction {
+        id: ActionId::ToggleSortOrder,
+        name: "Toggle sort order (asc/desc)",
+        keys: "s",
+    },
+    PaletteAction {
+        id: ActionId::YankRelativePath,
+        name: "Yank relative path to clipboard",
+        keys: "y",
+    },
+    PaletteAction {
+        id: ActionId::YankAbsolutePath,
+        name: "Yank absolute path to clipboard",
+        keys: "Y",
+    },
+    PaletteAction {
+        id: ActionId::ShowHelp,
+        name: "Show help overlay",
+        keys: "?",
+    },
+    // Quit appears for discoverability; palette dispatch treats it as a no-op
+    // because the event loop break cannot be triggered from a function call.
+    // Users should press q directly to quit.
+    PaletteAction {
+        id: ActionId::Quit,
+        name: "Quit trek",
+        keys: "q",
+    },
+];
+
+/// Return indices into PALETTE_ACTIONS where `query` is a case-insensitive
+/// substring of the action name. Empty query returns all indices.
+pub fn filter_palette(query: &str) -> Vec<usize> {
+    let q = query.to_lowercase();
+    PALETTE_ACTIONS
+        .iter()
+        .enumerate()
+        .filter(|(_, a)| q.is_empty() || a.name.to_lowercase().contains(&q))
+        .map(|(i, _)| i)
+        .collect()
+}

--- a/src/app/palette_ops.rs
+++ b/src/app/palette_ops.rs
@@ -1,0 +1,52 @@
+use super::{palette, App};
+
+impl App {
+    /// Open the command palette: reset query, rebuild filtered list, show overlay.
+    pub fn open_palette(&mut self) {
+        self.palette_mode = true;
+        self.palette_query.clear();
+        self.palette_filtered = palette::filter_palette("");
+        self.palette_selected = 0;
+    }
+
+    /// Close the command palette without executing any action.
+    pub fn close_palette(&mut self) {
+        self.palette_mode = false;
+        self.palette_query.clear();
+    }
+
+    /// Append a character to the palette query and re-filter.
+    pub fn palette_push_char(&mut self, c: char) {
+        self.palette_query.push(c);
+        self.palette_filtered = palette::filter_palette(&self.palette_query);
+        self.palette_selected = 0;
+    }
+
+    /// Remove the last character from the palette query and re-filter.
+    pub fn palette_pop_char(&mut self) {
+        self.palette_query.pop();
+        self.palette_filtered = palette::filter_palette(&self.palette_query);
+        self.palette_selected = 0;
+    }
+
+    /// Move the palette cursor down one row, clamped to the last result.
+    pub fn palette_move_down(&mut self) {
+        if !self.palette_filtered.is_empty() {
+            self.palette_selected =
+                (self.palette_selected + 1).min(self.palette_filtered.len() - 1);
+        }
+    }
+
+    /// Move the palette cursor up one row, clamped to 0.
+    pub fn palette_move_up(&mut self) {
+        self.palette_selected = self.palette_selected.saturating_sub(1);
+    }
+
+    /// Return the ActionId of the currently highlighted palette row, if any.
+    pub fn palette_selected_action(&self) -> Option<palette::ActionId> {
+        self.palette_filtered
+            .get(self.palette_selected)
+            .and_then(|&i| palette::PALETTE_ACTIONS.get(i))
+            .map(|a| a.id)
+    }
+}

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -561,3 +561,145 @@ fn selected_path_on_file_returns_some() {
     assert!(app.selected_path().is_some());
     let _ = std::fs::remove_dir_all(&tmp);
 }
+
+// ── command palette tests ────────────────────────────────────────────────────
+
+/// Given: empty query
+/// When: filter_palette("") is called
+/// Then: all actions are returned
+#[test]
+fn palette_filter_empty_query_returns_all() {
+    let results = crate::app::palette::filter_palette("");
+    assert_eq!(results.len(), crate::app::palette::PALETTE_ACTIONS.len());
+}
+
+/// Given: a query matching some action names
+/// When: filter_palette("sort") is called
+/// Then: only actions whose names contain "sort" are returned
+#[test]
+fn palette_filter_narrows_by_substring() {
+    let results = crate::app::palette::filter_palette("sort");
+    assert!(!results.is_empty(), "expected at least one sort action");
+    for &i in &results {
+        let name = crate::app::palette::PALETTE_ACTIONS[i].name.to_lowercase();
+        assert!(name.contains("sort"), "unexpected action: {}", name);
+    }
+}
+
+/// Given: a query that matches no action names
+/// When: filter_palette("zzznomatch") is called
+/// Then: empty vec returned
+#[test]
+fn palette_filter_no_match_returns_empty() {
+    let results = crate::app::palette::filter_palette("zzznomatch");
+    assert!(results.is_empty());
+}
+
+/// Given: palette is closed
+/// When: open_palette() is called
+/// Then: palette_mode is true, query is empty, filtered list is full
+#[test]
+fn open_palette_sets_mode_and_resets_query() {
+    let tmp = std::env::temp_dir().join(format!("trek_palette_open_{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&tmp);
+    let mut app = make_app_at(&tmp);
+    assert!(!app.palette_mode);
+    app.open_palette();
+    assert!(app.palette_mode);
+    assert!(app.palette_query.is_empty());
+    assert_eq!(
+        app.palette_filtered.len(),
+        crate::app::palette::PALETTE_ACTIONS.len()
+    );
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+/// Given: palette is open with a query
+/// When: close_palette() is called
+/// Then: palette_mode is false and query is cleared
+#[test]
+fn close_palette_clears_state() {
+    let tmp = std::env::temp_dir().join(format!("trek_palette_close_{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&tmp);
+    let mut app = make_app_at(&tmp);
+    app.open_palette();
+    app.palette_push_char('s');
+    app.palette_push_char('o');
+    app.close_palette();
+    assert!(!app.palette_mode);
+    assert!(app.palette_query.is_empty());
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+/// Given: palette is open with no query
+/// When: palette_push_char('q') is called
+/// Then: only actions containing "q" remain in filtered list; selected resets to 0
+#[test]
+fn palette_push_char_narrows_filtered_list() {
+    let tmp = std::env::temp_dir().join(format!("trek_palette_push_{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&tmp);
+    let mut app = make_app_at(&tmp);
+    app.open_palette();
+    let full_count = app.palette_filtered.len();
+    app.palette_push_char('q');
+    assert!(app.palette_filtered.len() < full_count);
+    assert_eq!(app.palette_selected, 0);
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+/// Given: palette query is "so"
+/// When: palette_pop_char() is called
+/// Then: query becomes "s" and filtered list widens
+#[test]
+fn palette_pop_char_widens_filtered_list() {
+    let tmp = std::env::temp_dir().join(format!("trek_palette_pop_{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&tmp);
+    let mut app = make_app_at(&tmp);
+    app.open_palette();
+    app.palette_push_char('s');
+    app.palette_push_char('o');
+    let narrow = app.palette_filtered.len();
+    app.palette_pop_char();
+    assert!(app.palette_filtered.len() >= narrow);
+    assert_eq!(&app.palette_query, "s");
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+/// Given: palette has multiple results
+/// When: palette_move_down() then palette_move_up() are called
+/// Then: selected changes appropriately and stays in bounds
+#[test]
+fn palette_navigation_stays_in_bounds() {
+    let tmp = std::env::temp_dir().join(format!("trek_palette_nav_{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&tmp);
+    let mut app = make_app_at(&tmp);
+    app.open_palette();
+    assert_eq!(app.palette_selected, 0);
+    app.palette_move_down();
+    assert_eq!(app.palette_selected, 1);
+    app.palette_move_up();
+    assert_eq!(app.palette_selected, 0);
+    // Moving up at top stays at 0
+    app.palette_move_up();
+    assert_eq!(app.palette_selected, 0);
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+/// Given: palette_selected_action() with a known action in the list
+/// When: called
+/// Then: returns Some(ActionId) for the selected entry
+#[test]
+fn palette_selected_action_returns_correct_id() {
+    let tmp = std::env::temp_dir().join(format!("trek_palette_sel_{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&tmp);
+    let mut app = make_app_at(&tmp);
+    app.open_palette();
+    // With empty query, first filtered entry is PALETTE_ACTIONS[0]
+    let action = app.palette_selected_action();
+    assert!(action.is_some());
+    assert_eq!(
+        action.unwrap(),
+        crate::app::palette::PALETTE_ACTIONS[app.palette_filtered[0]].id
+    );
+    let _ = std::fs::remove_dir_all(&tmp);
+}

--- a/src/args.rs
+++ b/src/args.rs
@@ -83,6 +83,7 @@ pub fn print_help() {
     println!("    x           Cut current to clipboard");
     println!("    p           Paste clipboard       Delete      Delete current file/dir");
     println!("    X           Delete all selected   M           Make new directory");
+    println!("    :           Open command palette");
     println!("    ?           Show help overlay  q           Quit");
 }
 

--- a/src/events.rs
+++ b/src/events.rs
@@ -124,6 +124,21 @@ pub fn run(
                         KeyCode::Char(c) => app.filter_push_char(c),
                         _ => {}
                     }
+                } else if app.palette_mode {
+                    match key.code {
+                        KeyCode::Esc | KeyCode::Char(':') => app.close_palette(),
+                        KeyCode::Enter | KeyCode::Char('l') | KeyCode::Right => {
+                            if let Some(action) = app.palette_selected_action() {
+                                app.close_palette();
+                                execute_palette_action(&mut app, action, terminal)?;
+                            }
+                        }
+                        KeyCode::Backspace => app.palette_pop_char(),
+                        KeyCode::Up | KeyCode::Char('k') => app.palette_move_up(),
+                        KeyCode::Down | KeyCode::Char('j') => app.palette_move_down(),
+                        KeyCode::Char(c) => app.palette_push_char(c),
+                        _ => {}
+                    }
                 } else if app.search_mode {
                     match key.code {
                         KeyCode::Esc => app.cancel_search(),
@@ -230,6 +245,8 @@ pub fn run(
                                 }
                             }
                         }
+                        // Open command palette
+                        KeyCode::Char(':') => app.open_palette(),
                         // Open with system default (open on macOS, xdg-open on Linux)
                         KeyCode::Char('O') => {
                             if let Some(path) = app.selected_path() {
@@ -288,4 +305,60 @@ pub fn run(
         }
     }
     Ok(app.cwd)
+}
+
+/// Dispatch a palette ActionId to the corresponding App method.
+///
+/// Actions that require terminal teardown (open-in-editor) are handled here
+/// because `events.rs` owns the terminal handle.
+fn execute_palette_action(
+    app: &mut App,
+    action: crate::app::palette::ActionId,
+    terminal: &mut ratatui::Terminal<CrosstermBackend<io::Stdout>>,
+) -> anyhow::Result<()> {
+    use crate::app::palette::ActionId;
+    match action {
+        ActionId::GoHome => app.go_home(),
+        ActionId::GoTop => app.go_top(),
+        ActionId::GoBottom => app.go_bottom(),
+        ActionId::HistoryBack => app.history_back(),
+        ActionId::HistoryForward => app.history_forward(),
+        ActionId::ToggleHidden => app.toggle_hidden(),
+        ActionId::ToggleDiffPreview => app.toggle_diff_preview(),
+        ActionId::ToggleMetaPreview => app.toggle_meta_preview(),
+        ActionId::RefreshGitStatus => app.refresh_git_status(),
+        ActionId::StartSearch => app.start_search(),
+        ActionId::StartFilter => app.start_filter(),
+        ActionId::StartContentSearch => app.start_content_search(),
+        ActionId::StartFind => app.start_find(),
+        ActionId::ClipboardCopyCurrent => app.clipboard_copy_current(),
+        ActionId::ClipboardCopySelected => app.clipboard_copy_selected(),
+        ActionId::ClipboardCutCurrent => app.clipboard_cut_current(),
+        ActionId::PasteClipboard => app.paste_clipboard(),
+        ActionId::BeginDeleteCurrent => app.begin_delete_current(),
+        ActionId::BeginDeleteSelected => app.begin_delete_selected(),
+        ActionId::BeginMkdir => app.begin_mkdir(),
+        ActionId::UndoTrash => app.undo_trash(),
+        ActionId::BeginChmod => app.begin_chmod(),
+        ActionId::ToggleSelection => {
+            let s = app.selected;
+            app.toggle_selection(s);
+        }
+        ActionId::SelectAll => app.select_all(),
+        ActionId::ClearSelections => app.clear_selections(),
+        ActionId::StartRename => app.start_rename(),
+        ActionId::AddBookmark => app.add_bookmark(),
+        ActionId::OpenBookmarks => app.open_bookmarks(),
+        ActionId::CycleSortMode => app.cycle_sort_mode(),
+        ActionId::ToggleSortOrder => app.toggle_sort_order(),
+        ActionId::YankRelativePath => app.yank_relative_path(),
+        ActionId::YankAbsolutePath => app.yank_absolute_path(),
+        ActionId::ShowHelp => app.show_help = true,
+        // Quit appears in the palette for discoverability but cannot break out
+        // of the event loop from here — use q directly.
+        ActionId::Quit => {}
+    }
+    // terminal is available here for any future actions needing TUI teardown.
+    let _ = terminal;
+    Ok(())
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -168,9 +168,14 @@ pub fn draw(f: &mut Frame, app: &mut App) {
         draw_help_overlay(f, size);
     }
 
-    // Bookmark picker overlay (rendered on top of everything else).
+    // Bookmark picker overlay.
     if app.bookmark_mode {
         draw_bookmark_overlay(f, app, size);
+    }
+
+    // Command palette overlay (rendered on top of everything else).
+    if app.palette_mode {
+        draw_palette_overlay(f, app, size);
     }
 }
 
@@ -1246,9 +1251,147 @@ fn draw_find_bar(f: &mut Frame, app: &App, area: Rect) {
     f.render_widget(para, area);
 }
 
+/// Render the command palette as a centered overlay.
+fn draw_palette_overlay(f: &mut Frame, app: &App, size: Rect) {
+    use crate::app::palette::PALETTE_ACTIONS;
+
+    // Up to 12 rows visible; minimum 6 for empty state.
+    const MAX_VISIBLE: usize = 12;
+    let visible_rows = app.palette_filtered.len().clamp(1, MAX_VISIBLE) as u16;
+    // +4 for border (2) + search bar (1) + footer hint (1)
+    let height = (visible_rows + 4).min(size.height.saturating_sub(4)).max(6);
+    let width = 72u16.min(size.width.saturating_sub(4));
+    let x = (size.width.saturating_sub(width)) / 2;
+    let y = (size.height.saturating_sub(height)) / 2;
+    let area = Rect::new(x, y, width, height);
+
+    f.render_widget(Clear, area);
+
+    let title = if app.palette_query.is_empty() {
+        " Command Palette ".to_string()
+    } else {
+        format!(" Command Palette  {} ", app.palette_query)
+    };
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Cyan))
+        .title(Span::styled(
+            title,
+            Style::default()
+                .fg(Color::White)
+                .add_modifier(Modifier::BOLD),
+        ));
+
+    let inner = block.inner(area);
+    f.render_widget(block, area);
+
+    if inner.height < 2 {
+        return;
+    }
+
+    // Split inner area: search bar on top, results below, hint at bottom.
+    let chunks = ratatui::layout::Layout::default()
+        .direction(ratatui::layout::Direction::Vertical)
+        .constraints([
+            ratatui::layout::Constraint::Length(1), // search bar
+            ratatui::layout::Constraint::Min(1),    // results
+            ratatui::layout::Constraint::Length(1), // hint
+        ])
+        .split(inner);
+
+    let search_area = chunks[0];
+    let results_area = chunks[1];
+    let hint_area = chunks[2];
+
+    // Search bar
+    let search_line = Line::from(vec![
+        Span::styled(
+            " > ",
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(
+            app.palette_query.as_str(),
+            Style::default()
+                .fg(Color::White)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled("\u{2588}", Style::default().fg(Color::White)),
+    ]);
+    f.render_widget(Paragraph::new(search_line), search_area);
+
+    // Results
+    if app.palette_filtered.is_empty() {
+        let empty = Paragraph::new(Line::from(Span::styled(
+            "  No matching actions",
+            Style::default().fg(Color::DarkGray),
+        )));
+        f.render_widget(empty, results_area);
+    } else {
+        let visible_height = results_area.height as usize;
+        let scroll = if app.palette_selected >= visible_height {
+            app.palette_selected - visible_height + 1
+        } else {
+            0
+        };
+
+        // Reserve space for key hint (10 chars + 1 space) on the right.
+        let keys_width: usize = 10;
+        let name_width = (results_area.width as usize).saturating_sub(keys_width + 3);
+
+        let items: Vec<ListItem> = app
+            .palette_filtered
+            .iter()
+            .enumerate()
+            .skip(scroll)
+            .take(visible_height)
+            .map(|(display_idx, &real_idx)| {
+                let action = &PALETTE_ACTIONS[real_idx];
+                let is_selected = display_idx == app.palette_selected;
+                let name = truncate_with_ellipsis(action.name, name_width);
+                let keys = format!("{:>width$}", action.keys, width = keys_width);
+
+                if is_selected {
+                    let style = Style::default()
+                        .fg(Color::White)
+                        .bg(Color::Blue)
+                        .add_modifier(Modifier::BOLD);
+                    ListItem::new(Line::from(vec![
+                        Span::styled(
+                            format!(" \u{25cf} {:<width$} ", name, width = name_width),
+                            style,
+                        ),
+                        Span::styled(keys, style),
+                    ]))
+                } else {
+                    ListItem::new(Line::from(vec![
+                        Span::styled(
+                            format!("   {:<width$} ", name, width = name_width),
+                            Style::default().fg(Color::White),
+                        ),
+                        Span::styled(keys, Style::default().fg(Color::DarkGray)),
+                    ]))
+                }
+            })
+            .collect();
+
+        let list = List::new(items);
+        f.render_widget(list, results_area);
+    }
+
+    // Footer hint
+    let hint = Paragraph::new(Line::from(Span::styled(
+        "  Enter=run  Esc=cancel  j/k=navigate",
+        Style::default().fg(Color::DarkGray),
+    )));
+    f.render_widget(hint, hint_area);
+}
+
 fn draw_help_overlay(f: &mut Frame, size: Rect) {
     let width = 60u16.min(size.width.saturating_sub(4));
-    let height = 48u16.min(size.height.saturating_sub(4));
+    let height = 49u16.min(size.height.saturating_sub(4));
     let x = (size.width.saturating_sub(width)) / 2;
     let y = (size.height.saturating_sub(height)) / 2;
     let area = Rect::new(x, y, width, height);
@@ -1308,6 +1451,7 @@ fn draw_help_overlay(f: &mut Frame, size: Rect) {
         // ── Yank & Misc ─────────────────────────────────────────────────────
         section_header("Yank & Misc"),
         key_line("y / Y", "Yank relative / absolute path"),
+        key_line(":", "Open command palette"),
         key_line("Q", "Quit"),
         key_line("?", "Toggle this help"),
         Line::from(""),


### PR DESCRIPTION
## Summary
- `:` opens a centered overlay listing all ~34 Trek actions with keybinding hints
- Typing narrows results via case-insensitive substring match; empty query shows all actions
- `Enter`/`l` executes the highlighted action and closes palette; `Esc`/`:` closes without executing; `j`/`k` and `Up`/`Down` navigate
- `Quit` shown for discoverability but is a no-op (event loop break cannot be triggered from a function)
- New `src/app/palette.rs` (action registry), `src/app/palette_ops.rs` (App methods), `execute_palette_action()` in `events.rs`
- `:` documented in help overlay and `--help`; 9 new unit tests (110 total)

Closes #32

## Acceptance criteria
- [x] `:` in normal mode opens the command palette overlay
- [x] All ~34 actions shown with keybinding hints
- [x] Typing narrows by name (case-insensitive substring)
- [x] `j`/`Down` and `k`/`Up` navigate filtered list
- [x] `Enter` executes selected action and closes palette
- [x] After execution, Trek behaves identically to pressing the direct keybinding
- [x] `Esc` or `:` closes without executing
- [x] Empty filter result shows "No matching actions"
- [x] Overlay centered and topmost
- [x] Quit action present but no-op in palette dispatcher
- [x] `:` documented in help overlay

## Test plan
- [x] `cargo test` — 110 passed, 0 failed
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt` — applied
- [x] `cargo build --release` — compiles as v0.18.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)