### PR TITLE
feat(rename): quick single-file rename via n / F2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.0] - 2026-03-24
+
+### Added
+- **`n` / `F2` — quick single-file rename**: opens a lightweight inline bar at the bottom pre-filled with the current entry's full name; typing edits the name in place; `Enter` renames via `std::fs::rename`, refreshes the listing, and moves the cursor to the renamed entry; `Esc` cancels with no changes
+- Empty input shows `"Name cannot be empty"` and closes the bar; name collision shows `"Already exists: <name>"` and closes the bar; same-name confirm is a silent no-op; works on both files and directories
+- Status bar shows `Renamed "old" → "new"` on success
+- `n` / `F2` registered in the command palette as `"Quick rename current file or directory"`
+- Both keybindings documented in the help overlay (`?`) under Selection & Rename and in `--help` output
+- 8 new unit tests covering: prefill, no-op on empty entries, cancel, same-name no-op, empty input error, successful rename, collision error, push/pop char
+
 ## [0.18.0] - 2026-03-24
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -586,7 +586,7 @@ dependencies = [
 
 [[package]]
 name = "trek"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trek"
-version = "0.18.0"
+version = "0.19.0"
 edition = "2021"
 rust-version = "1.80"
 description = "A terminal file manager with mouse-resizable panes"

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -20,6 +20,7 @@ mod navigation;
 pub mod palette;
 mod palette_ops;
 mod preview;
+mod quick_rename;
 mod rename;
 mod search;
 mod sort;
@@ -264,6 +265,12 @@ pub struct App {
     pub palette_selected: usize,
     /// Indices into `palette::PALETTE_ACTIONS` matching the current query.
     pub palette_filtered: Vec<usize>,
+
+    // --- Quick single-file rename (n / F2) ---
+    /// True when the quick rename bar is open.
+    pub quick_rename_mode: bool,
+    /// The text currently in the quick rename input bar.
+    pub quick_rename_input: String,
 }
 
 #[derive(Clone)]
@@ -359,6 +366,8 @@ impl App {
             palette_query: String::new(),
             palette_selected: 0,
             palette_filtered: palette::filter_palette(""),
+            quick_rename_mode: false,
+            quick_rename_input: String::new(),
         };
         app.load_dir();
         Ok(app)

--- a/src/app/palette.rs
+++ b/src/app/palette.rs
@@ -31,6 +31,7 @@ pub enum ActionId {
     ToggleSelection,
     SelectAll,
     ClearSelections,
+    QuickRename,
     StartRename,
     AddBookmark,
     OpenBookmarks,
@@ -176,6 +177,11 @@ pub static PALETTE_ACTIONS: &[PaletteAction] = &[
         id: ActionId::ClearSelections,
         name: "Clear selections",
         keys: "Esc",
+    },
+    PaletteAction {
+        id: ActionId::QuickRename,
+        name: "Quick rename current file or directory",
+        keys: "n / F2",
     },
     PaletteAction {
         id: ActionId::StartRename,

--- a/src/app/quick_rename.rs
+++ b/src/app/quick_rename.rs
@@ -1,0 +1,90 @@
+use super::App;
+use std::path::PathBuf;
+
+impl App {
+    /// Open the quick rename bar pre-filled with the currently selected entry's name.
+    /// No-op if there are no entries.
+    pub fn begin_quick_rename(&mut self) {
+        let Some(entry) = self.entries.get(self.selected) else {
+            return;
+        };
+        self.quick_rename_input = entry.name.clone();
+        self.quick_rename_mode = true;
+    }
+
+    /// Confirm the rename: validate, rename on disk, refresh listing, move cursor.
+    pub fn confirm_quick_rename(&mut self) {
+        let new_name = self.quick_rename_input.trim().to_string();
+
+        if new_name.is_empty() {
+            self.status_message = Some("Name cannot be empty".to_string());
+            self.quick_rename_mode = false;
+            self.quick_rename_input.clear();
+            return;
+        }
+
+        let Some(entry) = self.entries.get(self.selected).cloned() else {
+            self.quick_rename_mode = false;
+            self.quick_rename_input.clear();
+            return;
+        };
+
+        let old_name = entry.name.clone();
+
+        // No-op when name unchanged.
+        if new_name == old_name {
+            self.quick_rename_mode = false;
+            self.quick_rename_input.clear();
+            return;
+        }
+
+        let new_path = entry
+            .path
+            .parent()
+            .map(|p| p.join(&new_name))
+            .unwrap_or_else(|| PathBuf::from(&new_name));
+
+        if new_path.exists() {
+            self.status_message = Some(format!("Already exists: \"{}\"", new_name));
+            self.quick_rename_mode = false;
+            self.quick_rename_input.clear();
+            return;
+        }
+
+        self.quick_rename_mode = false;
+        self.quick_rename_input.clear();
+
+        match std::fs::rename(&entry.path, &new_path) {
+            Ok(()) => {
+                self.status_message = Some(format!(
+                    "Renamed \"{}\" \u{2192} \"{}\"",
+                    old_name, new_name
+                ));
+                self.load_dir();
+                if let Some(idx) = self.entries.iter().position(|e| e.name == new_name) {
+                    self.selected = idx;
+                    self.load_preview();
+                }
+            }
+            Err(e) => {
+                self.status_message = Some(format!("Rename failed: {}", e));
+            }
+        }
+    }
+
+    /// Cancel the quick rename bar without touching the filesystem.
+    pub fn cancel_quick_rename(&mut self) {
+        self.quick_rename_mode = false;
+        self.quick_rename_input.clear();
+    }
+
+    /// Append a character to the rename input.
+    pub fn quick_rename_push_char(&mut self, c: char) {
+        self.quick_rename_input.push(c);
+    }
+
+    /// Remove the last character from the rename input.
+    pub fn quick_rename_pop_char(&mut self) {
+        self.quick_rename_input.pop();
+    }
+}

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -703,3 +703,187 @@ fn palette_selected_action_returns_correct_id() {
     );
     let _ = std::fs::remove_dir_all(&tmp);
 }
+
+// ── quick rename tests ───────────────────────────────────────────────────────
+
+/// Given: a directory with a file selected
+/// When: begin_quick_rename() is called
+/// Then: quick_rename_mode is true, input is pre-filled with the current entry name
+#[test]
+fn begin_quick_rename_prefills_name() {
+    let tmp = std::env::temp_dir().join(format!("trek_qr_begin_{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&tmp);
+    std::fs::write(tmp.join("hello.txt"), b"").unwrap();
+
+    let mut app = make_app_at(&tmp);
+    if let Some(idx) = app.entries.iter().position(|e| !e.is_dir) {
+        app.selected = idx;
+    }
+    app.begin_quick_rename();
+    assert!(app.quick_rename_mode);
+    assert_eq!(app.quick_rename_input, "hello.txt");
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+/// Given: no entries in the listing
+/// When: begin_quick_rename() is called
+/// Then: quick_rename_mode stays false (no-op)
+#[test]
+fn begin_quick_rename_empty_entries_is_noop() {
+    let tmp = std::env::temp_dir().join(format!("trek_qr_empty_{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&tmp);
+    let mut app = make_app_at(&tmp);
+    app.entries.clear();
+    app.begin_quick_rename();
+    assert!(!app.quick_rename_mode);
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+/// Given: quick rename bar is open
+/// When: cancel_quick_rename() is called
+/// Then: mode is false, input is cleared, filesystem unchanged
+#[test]
+fn cancel_quick_rename_clears_state() {
+    let tmp = std::env::temp_dir().join(format!("trek_qr_cancel_{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&tmp);
+    std::fs::write(tmp.join("file.rs"), b"").unwrap();
+
+    let mut app = make_app_at(&tmp);
+    if let Some(idx) = app.entries.iter().position(|e| !e.is_dir) {
+        app.selected = idx;
+    }
+    app.begin_quick_rename();
+    app.cancel_quick_rename();
+    assert!(!app.quick_rename_mode);
+    assert!(app.quick_rename_input.is_empty());
+    assert!(tmp.join("file.rs").exists());
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+/// Given: quick rename bar is open with the original name
+/// When: Enter is pressed (confirm_quick_rename) with no changes
+/// Then: the file is NOT renamed (no-op), mode closes
+#[test]
+fn confirm_quick_rename_same_name_is_noop() {
+    let tmp = std::env::temp_dir().join(format!("trek_qr_same_{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&tmp);
+    std::fs::write(tmp.join("same.txt"), b"").unwrap();
+
+    let mut app = make_app_at(&tmp);
+    if let Some(idx) = app.entries.iter().position(|e| e.name == "same.txt") {
+        app.selected = idx;
+    }
+    app.begin_quick_rename();
+    // input already equals current name — confirm should be a no-op
+    app.confirm_quick_rename();
+    assert!(!app.quick_rename_mode);
+    assert!(tmp.join("same.txt").exists());
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+/// Given: quick rename bar is open
+/// When: input is cleared and Enter pressed
+/// Then: status message says "Name cannot be empty", bar stays open
+#[test]
+fn confirm_quick_rename_empty_input_shows_error() {
+    let tmp = std::env::temp_dir().join(format!("trek_qr_empty_in_{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&tmp);
+    std::fs::write(tmp.join("nonempty.txt"), b"").unwrap();
+
+    let mut app = make_app_at(&tmp);
+    if let Some(idx) = app.entries.iter().position(|e| !e.is_dir) {
+        app.selected = idx;
+    }
+    app.begin_quick_rename();
+    app.quick_rename_input.clear();
+    app.confirm_quick_rename();
+    // Mode should be closed (we close on empty) and status set
+    assert!(app.status_message.is_some());
+    let msg = app.status_message.as_deref().unwrap_or("");
+    assert!(
+        msg.contains("empty") || msg.contains("Empty"),
+        "expected empty-name error, got: {msg}"
+    );
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+/// Given: quick rename bar is open with a new valid name
+/// When: confirm_quick_rename() is called
+/// Then: file is renamed, listing refreshed, cursor on renamed entry, status shown
+#[test]
+fn confirm_quick_rename_renames_file() {
+    let tmp = std::env::temp_dir().join(format!("trek_qr_rename_{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&tmp);
+    std::fs::write(tmp.join("old.txt"), b"content").unwrap();
+
+    let mut app = make_app_at(&tmp);
+    if let Some(idx) = app.entries.iter().position(|e| e.name == "old.txt") {
+        app.selected = idx;
+    }
+    app.begin_quick_rename();
+    app.quick_rename_input = "new.txt".to_string();
+    app.confirm_quick_rename();
+
+    assert!(!app.quick_rename_mode);
+    assert!(tmp.join("new.txt").exists(), "renamed file should exist");
+    assert!(!tmp.join("old.txt").exists(), "old file should be gone");
+    assert!(
+        app.entries.iter().any(|e| e.name == "new.txt"),
+        "listing should contain new name"
+    );
+    let msg = app.status_message.as_deref().unwrap_or("");
+    assert!(
+        msg.contains("old.txt") && msg.contains("new.txt"),
+        "status should mention both names, got: {msg}"
+    );
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+/// Given: quick rename bar is open, target name already exists
+/// When: confirm_quick_rename() is called
+/// Then: status shows collision error, original file still exists
+#[test]
+fn confirm_quick_rename_collision_shows_error() {
+    let tmp = std::env::temp_dir().join(format!("trek_qr_coll_{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&tmp);
+    std::fs::write(tmp.join("a.txt"), b"").unwrap();
+    std::fs::write(tmp.join("b.txt"), b"").unwrap();
+
+    let mut app = make_app_at(&tmp);
+    if let Some(idx) = app.entries.iter().position(|e| e.name == "a.txt") {
+        app.selected = idx;
+    }
+    app.begin_quick_rename();
+    app.quick_rename_input = "b.txt".to_string();
+    app.confirm_quick_rename();
+
+    assert!(tmp.join("a.txt").exists(), "original should still exist");
+    let msg = app.status_message.as_deref().unwrap_or("");
+    assert!(
+        msg.contains("exists") || msg.contains("Exists") || msg.contains("Already"),
+        "expected collision error, got: {msg}"
+    );
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+/// Given: quick rename bar
+/// When: quick_rename_push_char and quick_rename_pop_char are called
+/// Then: input is updated correctly
+#[test]
+fn quick_rename_push_pop_char() {
+    let tmp = std::env::temp_dir().join(format!("trek_qr_chars_{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&tmp);
+    std::fs::write(tmp.join("test.txt"), b"").unwrap();
+
+    let mut app = make_app_at(&tmp);
+    if let Some(idx) = app.entries.iter().position(|e| !e.is_dir) {
+        app.selected = idx;
+    }
+    app.begin_quick_rename();
+    let original_len = app.quick_rename_input.len();
+    app.quick_rename_push_char('X');
+    assert_eq!(app.quick_rename_input.len(), original_len + 1);
+    app.quick_rename_pop_char();
+    assert_eq!(app.quick_rename_input.len(), original_len);
+    let _ = std::fs::remove_dir_all(&tmp);
+}

--- a/src/args.rs
+++ b/src/args.rs
@@ -77,7 +77,8 @@ pub fn print_help() {
     println!("    y / Y       Yank relative / absolute path");
     println!("    d           Toggle diff preview R           Refresh git status");
     println!("    Space       Toggle file selection v          Select all files");
-    println!("    r           Rename selected files Esc        Clear selections");
+    println!("    n / F2      Quick rename (inline bar pre-filled with current name)");
+    println!("    r           Bulk rename selected files with regex  Esc  Clear selections");
     println!("    o           Open in $EDITOR        O           Open with system default");
     println!("    c           Copy current to clipboard C          Copy selected to clipboard");
     println!("    x           Cut current to clipboard");

--- a/src/events.rs
+++ b/src/events.rs
@@ -107,6 +107,14 @@ pub fn run(
                         KeyCode::Char(c) => app.find_push_char(c),
                         _ => {}
                     }
+                } else if app.quick_rename_mode {
+                    match key.code {
+                        KeyCode::Esc => app.cancel_quick_rename(),
+                        KeyCode::Enter => app.confirm_quick_rename(),
+                        KeyCode::Backspace => app.quick_rename_pop_char(),
+                        KeyCode::Char(c) => app.quick_rename_push_char(c),
+                        _ => {}
+                    }
                 } else if app.chmod_mode {
                     match key.code {
                         KeyCode::Esc => app.cancel_chmod(),
@@ -198,6 +206,8 @@ pub fn run(
                         KeyCode::Delete => app.begin_delete_current(),
                         KeyCode::Char('X') => app.begin_delete_selected(),
                         KeyCode::Char('M') => app.begin_mkdir(),
+                        // Quick single-file rename
+                        KeyCode::Char('n') | KeyCode::F(2) => app.begin_quick_rename(),
                         KeyCode::Char('u') => app.undo_trash(),
                         KeyCode::Char('b') => app.add_bookmark(),
                         KeyCode::Char('B') => app.open_bookmarks(),
@@ -346,6 +356,7 @@ fn execute_palette_action(
         }
         ActionId::SelectAll => app.select_all(),
         ActionId::ClearSelections => app.clear_selections(),
+        ActionId::QuickRename => app.begin_quick_rename(),
         ActionId::StartRename => app.start_rename(),
         ActionId::AddBookmark => app.add_bookmark(),
         ActionId::OpenBookmarks => app.open_bookmarks(),

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -97,6 +97,8 @@ pub fn draw(f: &mut Frame, app: &mut App) {
         draw_rename_bar(f, app, bottom_area);
     } else if !app.pending_delete.is_empty() {
         draw_delete_confirm_bar(f, app, bottom_area);
+    } else if app.quick_rename_mode {
+        draw_quick_rename_bar(f, app, bottom_area);
     } else if app.mkdir_mode {
         draw_mkdir_bar(f, app, bottom_area);
     } else if app.chmod_mode {
@@ -343,6 +345,29 @@ fn draw_chmod_bar(f: &mut Frame, app: &App, area: Rect) {
         Span::styled("\u{2588}", Style::default().fg(Color::Yellow)),
         Span::styled(
             "  Enter=apply  Esc=cancel",
+            Style::default().fg(Color::DarkGray),
+        ),
+    ]));
+    f.render_widget(para, area);
+}
+
+fn draw_quick_rename_bar(f: &mut Frame, app: &App, area: Rect) {
+    let para = Paragraph::new(Line::from(vec![
+        Span::styled(
+            " Rename: ",
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(
+            app.quick_rename_input.as_str(),
+            Style::default()
+                .fg(Color::White)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled("\u{2588}", Style::default().fg(Color::White)),
+        Span::styled(
+            "  Enter=confirm  Esc=cancel",
             Style::default().fg(Color::DarkGray),
         ),
     ]));
@@ -1391,7 +1416,7 @@ fn draw_palette_overlay(f: &mut Frame, app: &App, size: Rect) {
 
 fn draw_help_overlay(f: &mut Frame, size: Rect) {
     let width = 60u16.min(size.width.saturating_sub(4));
-    let height = 49u16.min(size.height.saturating_sub(4));
+    let height = 51u16.min(size.height.saturating_sub(4));
     let x = (size.width.saturating_sub(width)) / 2;
     let y = (size.height.saturating_sub(height)) / 2;
     let area = Rect::new(x, y, width, height);
@@ -1434,7 +1459,8 @@ fn draw_help_overlay(f: &mut Frame, size: Rect) {
         section_header("Selection & Rename"),
         key_line("Space", "Toggle file selection"),
         key_line("v", "Select all files"),
-        key_line("r", "Rename selected files"),
+        key_line("n / F2", "Quick rename (inline bar pre-filled)"),
+        key_line("r", "Bulk rename selected files with regex"),
         key_line("Esc", "Clear filter (if active) or selections"),
         Line::from(""),
         // ── File Operations ─────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- `n` / `F2` opens an inline rename bar pre-filled with the current entry's full name
- Typing edits the name; `Enter` renames via `std::fs::rename`, refreshes listing, cursor moves to renamed entry; `Esc` cancels
- Empty input → `"Name cannot be empty"`; collision → `"Already exists: <name>"`; same-name confirm → silent no-op; works on files and directories
- Registered in the command palette as `"Quick rename current file or directory"`
- Documented in help overlay (`?`) and `--help`; 8 new unit tests (118 total)

Closes #29

## Acceptance criteria
- [x] `n` opens rename bar pre-filled with current entry's full name
- [x] `F2` is an alias (identical behaviour)
- [x] Bar renders as `Rename: <name>█  Enter=confirm  Esc=cancel`
- [x] Typing / Backspace updates the input
- [x] `Enter` renames via `std::fs::rename`; listing refreshed; cursor on renamed entry
- [x] Status bar shows `Renamed "old" → "new"` on success
- [x] `Esc` cancels without any changes
- [x] Empty input → error shown, bar closes
- [x] Name collision → error shown, original file intact
- [x] Same-name confirm → silent no-op
- [x] Works on directories as well as files
- [x] `r` bulk rename mode unaffected
- [x] Both bindings documented in help overlay and `--help`

## Test plan
- [x] `cargo test` — 118 passed, 0 failed
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt` — applied
- [x] `cargo build --release` — compiles as v0.19.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)