### PR TITLE
feat(nav): path jump bar via e key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.21.0] - 2026-03-24
+
+### Added
+- **`e` — path jump bar**: opens a bottom input bar where the user can type any absolute path, relative path, or `~/…` path; `Enter` navigates there, `Esc` cancels; if the target is a file, trek navigates to its parent directory and places the cursor on the file
+- Non-existent paths show an error in the status bar and leave the bar open for correction
+- `e` registered in the command palette as `"Jump to path (path jump bar)"`
+- `e` documented in help overlay (`?`) under Navigation and in `--help` output
+- 7 new unit tests covering: open/cancel, empty-input silent cancel, absolute dir navigation, file path navigates to parent and selects file, nonexistent path error, push/pop char
+
 ## [0.20.0] - 2026-03-24
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trek"
-version = "0.20.0"
+version = "0.21.0"
 edition = "2021"
 rust-version = "1.80"
 description = "A terminal file manager with mouse-resizable panes"

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -280,6 +280,12 @@ pub struct App {
     /// Cached set of gitignored entry names for the current directory.
     /// Populated by load_dir() when hide_gitignored is true.
     pub gitignored_names: std::collections::HashSet<String>,
+
+    // --- Path jump bar (e) ---
+    /// True while the path jump input bar is open.
+    pub path_mode: bool,
+    /// The path string the user is typing in the path jump bar.
+    pub path_input: String,
 }
 
 #[derive(Clone)]
@@ -379,6 +385,8 @@ impl App {
             quick_rename_input: String::new(),
             hide_gitignored: false,
             gitignored_names: std::collections::HashSet::new(),
+            path_mode: false,
+            path_input: String::new(),
         };
         app.load_dir();
         Ok(app)

--- a/src/app/navigation.rs
+++ b/src/app/navigation.rs
@@ -217,6 +217,97 @@ impl App {
         self.history_pos
     }
 
+    // --- Path jump bar (e) ---
+
+    /// Open the path jump input bar with an empty input.
+    pub fn begin_path_jump(&mut self) {
+        self.path_mode = true;
+        self.path_input.clear();
+    }
+
+    /// Close the path jump bar without navigating.
+    pub fn cancel_path_jump(&mut self) {
+        self.path_mode = false;
+        self.path_input.clear();
+    }
+
+    /// Confirm the path typed in the jump bar and navigate to it.
+    ///
+    /// - Empty input → silently close the bar.
+    /// - `~` prefix → expand to home directory.
+    /// - Existing directory → navigate there.
+    /// - Existing file → navigate to its parent and select the file.
+    /// - Non-existent path → show an error and keep the bar open.
+    pub fn confirm_path_jump(&mut self) {
+        if self.path_input.is_empty() {
+            self.path_mode = false;
+            return;
+        }
+
+        let raw = self.path_input.clone();
+        let expanded = if raw.starts_with('~') {
+            match dirs_home() {
+                Some(home) => {
+                    let rest = raw.trim_start_matches('~').trim_start_matches('/');
+                    if rest.is_empty() {
+                        home
+                    } else {
+                        home.join(rest)
+                    }
+                }
+                None => std::path::PathBuf::from(&raw),
+            }
+        } else {
+            std::path::PathBuf::from(&raw)
+        };
+
+        if expanded.is_dir() {
+            self.path_mode = false;
+            self.path_input.clear();
+            self.filter_input.clear();
+            self.filter_mode = false;
+            self.push_history(expanded.clone());
+            self.cwd = expanded;
+            self.selected = 0;
+            self.current_scroll = 0;
+            self.load_dir();
+        } else if expanded.is_file() {
+            if let Some(parent) = expanded.parent().map(|p| p.to_path_buf()) {
+                let file_name = expanded
+                    .file_name()
+                    .map(|n| n.to_string_lossy().into_owned());
+                self.path_mode = false;
+                self.path_input.clear();
+                self.filter_input.clear();
+                self.filter_mode = false;
+                self.push_history(parent.clone());
+                self.cwd = parent;
+                self.selected = 0;
+                self.current_scroll = 0;
+                self.load_dir();
+                if let Some(name) = file_name {
+                    if let Some(idx) = self.entries.iter().position(|e| e.name == name) {
+                        self.selected = idx;
+                        self.load_preview();
+                    }
+                }
+            }
+        } else {
+            self.status_message = Some(format!("Path not found: {}", expanded.display()));
+            // Keep bar open so user can correct the path.
+        }
+    }
+
+    /// Append a character to the path jump input.
+    pub fn path_push_char(&mut self, c: char) {
+        self.path_input.push(c);
+    }
+
+    /// Remove the last character from the path jump input.
+    pub fn path_pop_char(&mut self) {
+        self.path_input.pop();
+    }
+
     /// Returns the path of the currently selected file (not directory), or None.
     /// Used by the open-in-editor (`o`) handler which should not act on directories.
     pub fn selected_file_path(&self) -> Option<PathBuf> {

--- a/src/app/palette.rs
+++ b/src/app/palette.rs
@@ -40,6 +40,7 @@ pub enum ActionId {
     ToggleSortOrder,
     YankRelativePath,
     YankAbsolutePath,
+    PathJump,
     ShowHelp,
     Quit,
 }
@@ -223,6 +224,11 @@ pub static PALETTE_ACTIONS: &[PaletteAction] = &[
         id: ActionId::YankAbsolutePath,
         name: "Yank absolute path to clipboard",
         keys: "Y",
+    },
+    PaletteAction {
+        id: ActionId::PathJump,
+        name: "Jump to path (path jump bar)",
+        keys: "e",
     },
     PaletteAction {
         id: ActionId::ShowHelp,

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -999,3 +999,155 @@ fn hide_gitignored_field_toggles() {
 
     let _ = std::fs::remove_dir_all(&tmp);
 }
+
+// ── path jump bar tests ──────────────────────────────────────────────────────
+
+/// Given: normal mode
+/// When: begin_path_jump() is called
+/// Then: path_mode is true, path_input is empty
+#[test]
+fn begin_path_jump_opens_bar() {
+    let tmp = std::env::temp_dir().join(format!("trek_pj_begin_{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&tmp);
+    let mut app = make_app_at(&tmp);
+    assert!(!app.path_mode);
+    app.begin_path_jump();
+    assert!(app.path_mode);
+    assert!(app.path_input.is_empty());
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+/// Given: path jump bar is open
+/// When: cancel_path_jump() is called
+/// Then: path_mode is false, input cleared, cwd unchanged
+#[test]
+fn cancel_path_jump_clears_without_navigating() {
+    let tmp = std::env::temp_dir().join(format!("trek_pj_cancel_{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&tmp);
+    let mut app = make_app_at(&tmp);
+    let original_cwd = app.cwd.clone();
+    app.begin_path_jump();
+    app.path_push_char('/');
+    app.path_push_char('t');
+    app.path_push_char('m');
+    app.path_push_char('p');
+    app.cancel_path_jump();
+    assert!(!app.path_mode);
+    assert!(app.path_input.is_empty());
+    assert_eq!(app.cwd, original_cwd);
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+/// Given: path jump bar with empty input
+/// When: confirm_path_jump() is called
+/// Then: bar closes silently (no crash, no navigation)
+#[test]
+fn confirm_path_jump_empty_input_cancels_silently() {
+    let tmp = std::env::temp_dir().join(format!("trek_pj_empty_{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&tmp);
+    let mut app = make_app_at(&tmp);
+    app.begin_path_jump();
+    app.confirm_path_jump();
+    assert!(!app.path_mode);
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+/// Given: path jump bar with a valid absolute directory path
+/// When: confirm_path_jump() is called
+/// Then: cwd changes to the target directory, history entry pushed
+#[test]
+fn confirm_path_jump_absolute_dir_navigates() {
+    let tmp = std::env::temp_dir().join(format!("trek_pj_abs_{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&tmp);
+    let target = std::env::temp_dir().join(format!("trek_pj_target_{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&target);
+    let canonical_target = target.canonicalize().unwrap();
+
+    let mut app = make_app_at(&tmp);
+    app.begin_path_jump();
+    for c in canonical_target.to_string_lossy().chars() {
+        app.path_push_char(c);
+    }
+    app.confirm_path_jump();
+
+    assert!(!app.path_mode, "bar should be closed after navigation");
+    assert_eq!(app.cwd, canonical_target, "cwd should be the target dir");
+
+    let _ = std::fs::remove_dir_all(&tmp);
+    let _ = std::fs::remove_dir_all(&target);
+}
+
+/// Given: path jump bar with a path to an existing file
+/// When: confirm_path_jump() is called
+/// Then: cwd becomes the file's parent directory and the file is selected
+#[test]
+fn confirm_path_jump_file_path_navigates_to_parent() {
+    let tmp = std::env::temp_dir().join(format!("trek_pj_file_{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&tmp);
+    let file = tmp.join("target_file.txt");
+    std::fs::write(&file, b"content").unwrap();
+    let canonical_file = file.canonicalize().unwrap();
+    let canonical_dir = tmp.canonicalize().unwrap();
+
+    let start = std::env::temp_dir().join(format!("trek_pj_start_{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&start);
+    let mut app = make_app_at(&start);
+    app.begin_path_jump();
+    for c in canonical_file.to_string_lossy().chars() {
+        app.path_push_char(c);
+    }
+    app.confirm_path_jump();
+
+    assert!(!app.path_mode, "bar should be closed");
+    assert_eq!(app.cwd, canonical_dir, "cwd should be file's parent");
+    // Cursor should be on target_file.txt
+    let selected_name = app.entries.get(app.selected).map(|e| e.name.as_str());
+    assert_eq!(
+        selected_name,
+        Some("target_file.txt"),
+        "cursor should land on the file"
+    );
+
+    let _ = std::fs::remove_dir_all(&tmp);
+    let _ = std::fs::remove_dir_all(&start);
+}
+
+/// Given: path jump bar with a nonexistent path
+/// When: confirm_path_jump() is called
+/// Then: status message is shown and bar stays open
+#[test]
+fn confirm_path_jump_nonexistent_path_shows_error() {
+    let tmp = std::env::temp_dir().join(format!("trek_pj_noex_{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&tmp);
+    let mut app = make_app_at(&tmp);
+    app.begin_path_jump();
+    // Type a path that cannot exist
+    for c in "/absolutely/does/not/exist/xyz_99999".chars() {
+        app.path_push_char(c);
+    }
+    app.confirm_path_jump();
+
+    // Bar stays open for correction
+    assert!(app.path_mode, "bar should stay open on error");
+    assert!(app.status_message.is_some(), "status message should be set");
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+/// Given: path jump bar with push/pop char
+/// When: characters are added and removed
+/// Then: path_input reflects changes correctly
+#[test]
+fn path_jump_push_pop_char() {
+    let tmp = std::env::temp_dir().join(format!("trek_pj_chars_{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&tmp);
+    let mut app = make_app_at(&tmp);
+    app.begin_path_jump();
+    app.path_push_char('/');
+    app.path_push_char('t');
+    app.path_push_char('m');
+    app.path_push_char('p');
+    assert_eq!(app.path_input, "/tmp");
+    app.path_pop_char();
+    assert_eq!(app.path_input, "/tm");
+    let _ = std::fs::remove_dir_all(&tmp);
+}

--- a/src/args.rs
+++ b/src/args.rs
@@ -73,6 +73,7 @@ pub fn print_help() {
     println!("    l / Right   Enter directory    h / Left    Go to parent");
     println!("    g           Go to top          G           Go to bottom");
     println!("    ~           Go to home         .           Toggle hidden files");
+    println!("    e           Jump to typed path (absolute, relative, or ~/…)");
     println!("    /           Fuzzy search       Ctrl+F      Content search (rg)");
     println!("    y / Y       Yank relative / absolute path");
     println!("    i           Toggle gitignore filter (hide .gitignored files)");

--- a/src/events.rs
+++ b/src/events.rs
@@ -132,6 +132,14 @@ pub fn run(
                         KeyCode::Char(c) => app.filter_push_char(c),
                         _ => {}
                     }
+                } else if app.path_mode {
+                    match key.code {
+                        KeyCode::Esc => app.cancel_path_jump(),
+                        KeyCode::Enter => app.confirm_path_jump(),
+                        KeyCode::Backspace => app.path_pop_char(),
+                        KeyCode::Char(c) => app.path_push_char(c),
+                        _ => {}
+                    }
                 } else if app.palette_mode {
                     match key.code {
                         KeyCode::Esc | KeyCode::Char(':') => app.close_palette(),
@@ -258,6 +266,8 @@ pub fn run(
                                 }
                             }
                         }
+                        // Path jump bar
+                        KeyCode::Char('e') => app.begin_path_jump(),
                         // Open command palette
                         KeyCode::Char(':') => app.open_palette(),
                         // Open with system default (open on macOS, xdg-open on Linux)
@@ -368,6 +378,7 @@ fn execute_palette_action(
         ActionId::ToggleSortOrder => app.toggle_sort_order(),
         ActionId::YankRelativePath => app.yank_relative_path(),
         ActionId::YankAbsolutePath => app.yank_absolute_path(),
+        ActionId::PathJump => app.begin_path_jump(),
         ActionId::ShowHelp => app.show_help = true,
         // Quit appears in the palette for discoverability but cannot break out
         // of the event loop from here — use q directly.

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -99,6 +99,8 @@ pub fn draw(f: &mut Frame, app: &mut App) {
         draw_delete_confirm_bar(f, app, bottom_area);
     } else if app.quick_rename_mode {
         draw_quick_rename_bar(f, app, bottom_area);
+    } else if app.path_mode {
+        draw_path_jump_bar(f, app, bottom_area);
     } else if app.mkdir_mode {
         draw_mkdir_bar(f, app, bottom_area);
     } else if app.chmod_mode {
@@ -378,6 +380,29 @@ fn draw_quick_rename_bar(f: &mut Frame, app: &App, area: Rect) {
         Span::styled("\u{2588}", Style::default().fg(Color::White)),
         Span::styled(
             "  Enter=confirm  Esc=cancel",
+            Style::default().fg(Color::DarkGray),
+        ),
+    ]));
+    f.render_widget(para, area);
+}
+
+fn draw_path_jump_bar(f: &mut Frame, app: &App, area: Rect) {
+    let para = Paragraph::new(Line::from(vec![
+        Span::styled(
+            " Jump to: ",
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(
+            app.path_input.as_str(),
+            Style::default()
+                .fg(Color::White)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled("\u{2588}", Style::default().fg(Color::White)),
+        Span::styled(
+            "  Enter=go  Esc=cancel",
             Style::default().fg(Color::DarkGray),
         ),
     ]));
@@ -1426,7 +1451,7 @@ fn draw_palette_overlay(f: &mut Frame, app: &App, size: Rect) {
 
 fn draw_help_overlay(f: &mut Frame, size: Rect) {
     let width = 60u16.min(size.width.saturating_sub(4));
-    let height = 52u16.min(size.height.saturating_sub(4));
+    let height = 54u16.min(size.height.saturating_sub(4));
     let x = (size.width.saturating_sub(width)) / 2;
     let y = (size.height.saturating_sub(height)) / 2;
     let area = Rect::new(x, y, width, height);
@@ -1444,6 +1469,7 @@ fn draw_help_overlay(f: &mut Frame, size: Rect) {
         key_line("g / G", "Go to top / bottom"),
         key_line("~", "Go to home directory"),
         key_line(".", "Toggle hidden files"),
+        key_line("e", "Jump to path (type any absolute/relative path)"),
         key_line("Ctrl+O", "Go back in directory history"),
         key_line("Ctrl+I", "Go forward in directory history"),
         Line::from(""),


### PR DESCRIPTION
## Summary

- Adds `e` key to open a path jump input bar at the bottom of the screen
- Supports absolute paths, relative paths, and `~/…` home-relative paths
- Navigating to a directory pushes history and enters it; navigating to a file jumps to its parent and places the cursor on the file
- Non-existent paths display an error and leave the bar open for correction; empty input silently closes the bar
- `e` registered in the command palette as "Jump to path (path jump bar)"
- Help overlay (`?`) and `--help` output updated under Navigation
- Bumps version to v0.21.0

## Test plan

- [x] 7 new unit tests: open bar, cancel without navigating, empty input cancel, absolute dir navigation, file path navigates to parent and selects file, nonexistent path error, push/pop char
- [x] All 130 tests pass
- [x] `cargo fmt`, `cargo clippy -- -D warnings`, `cargo build --release` all clean

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)