### PR TITLE
feat(select): range selection via J/K keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.0] - 2026-03-24
+
+### Added
+- **`J` / `K` — range selection**: pressing `J` (Shift+j) marks the current entry as selected, moves the cursor down, and marks the new current entry; `K` does the same moving up; enables fast contiguous multi-file selection without pressing Space on each entry individually
+- Both `J` and `K` include all entry types (files and directories) in the selection so bulk copy (`C`) and bulk delete (`X`) work naturally with directory entries; `start_rename` (`r`) filters out directories and shows an informative message if no files remain
+- `J`/`K` stop at list boundaries without wrapping — the boundary entry is marked and the cursor stays
+- Updated `start_rename()` guard: previously rejected an empty `rename_selected` set; now rejects selections that contain no *file* entries (e.g. only directories from range selection) with the message "No files selected (directories cannot be renamed in bulk)"
+- `J`/`K` registered in the command palette under "Extend selection down/up (range select)"
+- `J`/`K` documented in help overlay (`?`) under Selection & Rename and in `--help` output
+- 6 new unit tests: down marks both endpoints, up marks both endpoints, bottom boundary stays and marks, top boundary stays and marks, directories included in range selection, only-dirs selection shows appropriate message in start_rename
+
 ## [0.21.0] - 2026-03-24
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trek"
-version = "0.21.0"
+version = "0.22.0"
 edition = "2021"
 rust-version = "1.80"
 description = "A terminal file manager with mouse-resizable panes"

--- a/src/app/palette.rs
+++ b/src/app/palette.rs
@@ -29,6 +29,8 @@ pub enum ActionId {
     BeginMkdir,
     UndoTrash,
     BeginChmod,
+    SelectMoveDown,
+    SelectMoveUp,
     ToggleSelection,
     SelectAll,
     ClearSelections,
@@ -169,6 +171,16 @@ pub static PALETTE_ACTIONS: &[PaletteAction] = &[
         id: ActionId::BeginChmod,
         name: "chmod — edit file permissions",
         keys: "P",
+    },
+    PaletteAction {
+        id: ActionId::SelectMoveDown,
+        name: "Extend selection down (range select)",
+        keys: "J",
+    },
+    PaletteAction {
+        id: ActionId::SelectMoveUp,
+        name: "Extend selection up (range select)",
+        keys: "K",
     },
     PaletteAction {
         id: ActionId::ToggleSelection,

--- a/src/app/rename.rs
+++ b/src/app/rename.rs
@@ -38,10 +38,52 @@ impl App {
         self.status_message = None;
     }
 
-    /// Enter rename mode (requires at least one file to be selected).
+    /// Move cursor down while extending the selection (J key).
+    ///
+    /// Marks the current entry, moves down, and marks the new current entry.
+    /// All entry types (including directories) are added to the selection —
+    /// callers that only operate on files (e.g. start_rename) filter at their
+    /// own boundary. At the bottom of the list the cursor stays and the last
+    /// entry is marked.
+    pub fn select_move_down(&mut self) {
+        self.rename_selected.insert(self.selected);
+        if !self.entries.is_empty() && self.selected < self.entries.len() - 1 {
+            self.selected += 1;
+        }
+        self.rename_selected.insert(self.selected);
+        self.load_preview();
+    }
+
+    /// Move cursor up while extending the selection (K key).
+    ///
+    /// Mirrors `select_move_down`. At the top of the list the cursor stays
+    /// and the first entry is marked.
+    pub fn select_move_up(&mut self) {
+        self.rename_selected.insert(self.selected);
+        if self.selected > 0 {
+            self.selected -= 1;
+        }
+        self.rename_selected.insert(self.selected);
+        self.load_preview();
+    }
+
+    /// Enter rename mode (requires at least one *file* to be selected).
+    ///
+    /// Range selection (J/K) can add directories to `rename_selected`.
+    /// Directories are skipped by the rename logic, so only count files.
     pub fn start_rename(&mut self) {
-        if self.rename_selected.is_empty() {
-            self.status_message = Some("No files selected".to_string());
+        let file_count = self
+            .rename_selected
+            .iter()
+            .filter_map(|&i| self.entries.get(i))
+            .filter(|e| !e.is_dir)
+            .count();
+        if file_count == 0 {
+            self.status_message = Some(if self.rename_selected.is_empty() {
+                "No files selected".to_string()
+            } else {
+                "No files selected (directories cannot be renamed in bulk)".to_string()
+            });
             return;
         }
         self.rename_mode = true;

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -1151,3 +1151,140 @@ fn path_jump_push_pop_char() {
     assert_eq!(app.path_input, "/tm");
     let _ = std::fs::remove_dir_all(&tmp);
 }
+
+// ── range selection (J / K) tests ──────────────────────────────────────────────
+
+/// Given: cursor at index 0 in a multi-file directory
+/// When: select_move_down() is called once
+/// Then: entries 0 and 1 are selected, cursor is at 1
+#[test]
+fn select_move_down_marks_both_endpoints() {
+    let tmp = std::env::temp_dir().join(format!("trek_rsel_down_{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&tmp);
+    std::fs::write(tmp.join("a.txt"), b"").unwrap();
+    std::fs::write(tmp.join("b.txt"), b"").unwrap();
+    std::fs::write(tmp.join("c.txt"), b"").unwrap();
+    let mut app = make_app_at(&tmp);
+    app.selected = 0;
+    app.select_move_down();
+    assert!(
+        app.rename_selected.contains(&0),
+        "entry 0 should be selected"
+    );
+    assert!(
+        app.rename_selected.contains(&1),
+        "entry 1 should be selected"
+    );
+    assert_eq!(app.selected, 1, "cursor should be at 1");
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+/// Given: cursor at index 1 in a multi-file directory
+/// When: select_move_up() is called once
+/// Then: entries 1 and 0 are selected, cursor is at 0
+#[test]
+fn select_move_up_marks_both_endpoints() {
+    let tmp = std::env::temp_dir().join(format!("trek_rsel_up_{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&tmp);
+    std::fs::write(tmp.join("a.txt"), b"").unwrap();
+    std::fs::write(tmp.join("b.txt"), b"").unwrap();
+    let mut app = make_app_at(&tmp);
+    app.selected = 1;
+    app.select_move_up();
+    assert!(
+        app.rename_selected.contains(&1),
+        "entry 1 should be selected"
+    );
+    assert!(
+        app.rename_selected.contains(&0),
+        "entry 0 should be selected"
+    );
+    assert_eq!(app.selected, 0, "cursor should be at 0");
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+/// Given: cursor at the last entry
+/// When: select_move_down() is called
+/// Then: cursor stays at last entry; last entry is marked
+#[test]
+fn select_move_down_at_bottom_stays_and_marks() {
+    let tmp = std::env::temp_dir().join(format!("trek_rsel_bot_{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&tmp);
+    std::fs::write(tmp.join("a.txt"), b"").unwrap();
+    std::fs::write(tmp.join("b.txt"), b"").unwrap();
+    let mut app = make_app_at(&tmp);
+    app.selected = app.entries.len() - 1;
+    let last = app.selected;
+    app.select_move_down();
+    assert_eq!(app.selected, last, "cursor should not move past bottom");
+    assert!(
+        app.rename_selected.contains(&last),
+        "last entry should be selected"
+    );
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+/// Given: cursor at index 0 (top)
+/// When: select_move_up() is called
+/// Then: cursor stays at 0; entry 0 is marked
+#[test]
+fn select_move_up_at_top_stays_and_marks() {
+    let tmp = std::env::temp_dir().join(format!("trek_rsel_top_{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&tmp);
+    std::fs::write(tmp.join("a.txt"), b"").unwrap();
+    std::fs::write(tmp.join("b.txt"), b"").unwrap();
+    let mut app = make_app_at(&tmp);
+    app.selected = 0;
+    app.select_move_up();
+    assert_eq!(app.selected, 0, "cursor should not move above top");
+    assert!(
+        app.rename_selected.contains(&0),
+        "entry 0 should be selected"
+    );
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+/// Given: directory entries in selection, no file entries
+/// When: start_rename() is called
+/// Then: status message shown, rename_mode stays false
+#[test]
+fn start_rename_with_only_dirs_in_selection_shows_message() {
+    let tmp = std::env::temp_dir().join(format!("trek_rsel_dir_{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&tmp);
+    let subdir = tmp.join("subdir");
+    let _ = std::fs::create_dir_all(&subdir);
+    // Also need a file so load_dir has entries
+    std::fs::write(tmp.join("file.txt"), b"").unwrap();
+    let mut app = make_app_at(&tmp);
+    // Find the directory entry and add it to selection
+    let dir_idx = app.entries.iter().position(|e| e.is_dir).unwrap();
+    app.rename_selected.insert(dir_idx);
+    app.start_rename();
+    assert!(
+        !app.rename_mode,
+        "rename_mode should be false when only dirs selected"
+    );
+    assert!(app.status_message.is_some(), "status message should be set");
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+/// Given: a directory entry selected by J (select_move_down includes dirs)
+/// When: cursor is on a directory, select_move_down called
+/// Then: the directory index is in rename_selected
+#[test]
+fn select_move_down_includes_directories() {
+    let tmp = std::env::temp_dir().join(format!("trek_rsel_incdir_{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&tmp);
+    let _ = std::fs::create_dir_all(tmp.join("aaa_dir"));
+    std::fs::write(tmp.join("zzz_file.txt"), b"").unwrap();
+    let mut app = make_app_at(&tmp);
+    // Dirs appear first in sorted listing
+    app.selected = 0;
+    assert!(app.entries[0].is_dir, "first entry should be a dir");
+    app.select_move_down();
+    assert!(
+        app.rename_selected.contains(&0),
+        "directory at index 0 should be in rename_selected"
+    );
+    let _ = std::fs::remove_dir_all(&tmp);
+}

--- a/src/args.rs
+++ b/src/args.rs
@@ -78,6 +78,7 @@ pub fn print_help() {
     println!("    y / Y       Yank relative / absolute path");
     println!("    i           Toggle gitignore filter (hide .gitignored files)");
     println!("    d           Toggle diff preview R           Refresh git status");
+    println!("    J           Extend selection down  K           Extend selection up");
     println!("    Space       Toggle file selection v          Select all files");
     println!("    n / F2      Quick rename (inline bar pre-filled with current name)");
     println!("    r           Bulk rename selected files with regex  Esc  Clear selections");

--- a/src/events.rs
+++ b/src/events.rs
@@ -176,6 +176,8 @@ pub fn run(
                         KeyCode::Char('Q') | KeyCode::Char('q') => break,
                         KeyCode::Up | KeyCode::Char('k') => app.move_up(),
                         KeyCode::Down | KeyCode::Char('j') => app.move_down(),
+                        KeyCode::Char('K') => app.select_move_up(),
+                        KeyCode::Char('J') => app.select_move_down(),
                         KeyCode::Left | KeyCode::Char('h') => app.go_parent(),
                         KeyCode::Right | KeyCode::Char('l') | KeyCode::Enter => {
                             app.enter_selected()
@@ -364,6 +366,8 @@ fn execute_palette_action(
         ActionId::BeginMkdir => app.begin_mkdir(),
         ActionId::UndoTrash => app.undo_trash(),
         ActionId::BeginChmod => app.begin_chmod(),
+        ActionId::SelectMoveDown => app.select_move_down(),
+        ActionId::SelectMoveUp => app.select_move_up(),
         ActionId::ToggleSelection => {
             let s = app.selected;
             app.toggle_selection(s);

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1451,7 +1451,7 @@ fn draw_palette_overlay(f: &mut Frame, app: &App, size: Rect) {
 
 fn draw_help_overlay(f: &mut Frame, size: Rect) {
     let width = 60u16.min(size.width.saturating_sub(4));
-    let height = 54u16.min(size.height.saturating_sub(4));
+    let height = 56u16.min(size.height.saturating_sub(4));
     let x = (size.width.saturating_sub(width)) / 2;
     let y = (size.height.saturating_sub(height)) / 2;
     let area = Rect::new(x, y, width, height);
@@ -1494,6 +1494,7 @@ fn draw_help_overlay(f: &mut Frame, size: Rect) {
         Line::from(""),
         // ── Selection & Rename ──────────────────────────────────────────────
         section_header("Selection & Rename"),
+        key_line("J / K", "Extend selection down / up (range select)"),
         key_line("Space", "Toggle file selection"),
         key_line("v", "Select all files"),
         key_line("n / F2", "Quick rename (inline bar pre-filled)"),


### PR DESCRIPTION
## Summary

- Adds `J` (Shift+j) and `K` (Shift+k) for extending the selection while moving the cursor
- Pressing `J` marks the current entry, moves down, and marks the new entry; `K` does the same moving up
- All entry types (files and directories) are included in the selection — bulk copy (`C`) and delete (`X`) work naturally; `r` (bulk rename) filters out directories and shows an informative message if no files remain
- Boundaries: cursor stops without wrapping; the boundary entry is marked
- Updated `start_rename()` to reject directory-only selections with a clear message instead of silently ignoring
- `J`/`K` registered in the command palette and documented in help overlay and `--help`
- Bumps version to v0.22.0

## Test plan

- [x] 6 new unit tests: down/up mark both endpoints, bottom/top boundary stays and marks, directories included in range selection, only-dirs selection shows message in start_rename
- [x] All 136 tests pass
- [x] `cargo fmt`, `cargo clippy -- -D warnings`, `cargo build --release` all clean

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)