### PR TITLE
feat(preview): keyboard scroll via [ / ] keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.23.0] - 2026-03-24
+
+### Added
+- **`[` / `]` — preview pane keyboard scrolling**: scrolls the preview pane up or down 5 lines per keypress in normal mode; complements the existing mouse-wheel scroll (3 lines per event) and gives keyboard-only users full access to any file longer than the visible pane height
+- Works in all preview modes: raw content, syntax-highlighted content, diff preview (`d`), file metadata view (`m`), and directory child listings
+- `[` clamps at scroll offset 0 (no underflow); `]` clamps at `preview_lines.len() - 1` (no overshoot); both are no-ops on empty previews
+- Navigating to a different file resets preview scroll to 0 (existing behaviour, no regression)
+- `[`/`]` registered in the command palette as "Scroll preview pane up/down"
+- `[`/`]` documented in help overlay (`?`) under Navigation and in `--help` output
+- 5 new unit tests: down advances offset, up decreases offset, top clamps at 0, bottom clamps at max, empty preview is no-op
+
 ## [0.22.0] - 2026-03-24
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trek"
-version = "0.22.0"
+version = "0.23.0"
 edition = "2021"
 rust-version = "1.80"
 description = "A terminal file manager with mouse-resizable panes"

--- a/src/app/palette.rs
+++ b/src/app/palette.rs
@@ -42,6 +42,8 @@ pub enum ActionId {
     ToggleSortOrder,
     YankRelativePath,
     YankAbsolutePath,
+    ScrollPreviewUp,
+    ScrollPreviewDown,
     PathJump,
     ShowHelp,
     Quit,
@@ -236,6 +238,16 @@ pub static PALETTE_ACTIONS: &[PaletteAction] = &[
         id: ActionId::YankAbsolutePath,
         name: "Yank absolute path to clipboard",
         keys: "Y",
+    },
+    PaletteAction {
+        id: ActionId::ScrollPreviewUp,
+        name: "Scroll preview pane up",
+        keys: "[",
+    },
+    PaletteAction {
+        id: ActionId::ScrollPreviewDown,
+        name: "Scroll preview pane down",
+        keys: "]",
     },
     PaletteAction {
         id: ActionId::PathJump,

--- a/src/app/preview.rs
+++ b/src/app/preview.rs
@@ -100,6 +100,22 @@ impl App {
         Vec::new()
     }
 
+    /// Scroll the preview pane up by `lines` lines.
+    ///
+    /// Clamps at 0 — no-op and no panic when already at the top.
+    pub fn scroll_preview_up(&mut self, lines: usize) {
+        self.preview_scroll = self.preview_scroll.saturating_sub(lines);
+    }
+
+    /// Scroll the preview pane down by `lines` lines.
+    ///
+    /// Clamps at `preview_lines.len() - 1` — no-op when at the bottom or
+    /// when the preview is empty.
+    pub fn scroll_preview_down(&mut self, lines: usize) {
+        let max_scroll = self.preview_lines.len().saturating_sub(1);
+        self.preview_scroll = (self.preview_scroll + lines).min(max_scroll);
+    }
+
     /// Toggle diff preview mode for the currently selected file.
     ///
     /// Has no effect outside a git repo or when the selected item is a

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -1288,3 +1288,109 @@ fn select_move_down_includes_directories() {
     );
     let _ = std::fs::remove_dir_all(&tmp);
 }
+
+// ── preview scroll ([ / ]) tests ─────────────────────────────────────────────
+
+/// Given: a file with 20 lines loaded in preview, scroll at 0
+/// When: scroll_preview_down(5) is called
+/// Then: preview_scroll is 5
+#[test]
+fn scroll_preview_down_advances_offset() {
+    let tmp = std::env::temp_dir().join(format!("trek_pscroll_dn_{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&tmp);
+    let content: String = (1..=20).map(|i| format!("line {}\n", i)).collect();
+    std::fs::write(tmp.join("big.txt"), content.as_bytes()).unwrap();
+    let mut app = make_app_at(&tmp);
+    let idx = app
+        .entries
+        .iter()
+        .position(|e| e.name == "big.txt")
+        .unwrap();
+    app.selected = idx;
+    app.load_preview();
+    assert!(app.preview_lines.len() >= 10, "preview should have lines");
+    app.scroll_preview_down(5);
+    assert_eq!(app.preview_scroll, 5);
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+/// Given: preview_scroll is 5
+/// When: scroll_preview_up(3) is called
+/// Then: preview_scroll is 2
+#[test]
+fn scroll_preview_up_decreases_offset() {
+    let tmp = std::env::temp_dir().join(format!("trek_pscroll_up_{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&tmp);
+    let content: String = (1..=20).map(|i| format!("line {}\n", i)).collect();
+    std::fs::write(tmp.join("big.txt"), content.as_bytes()).unwrap();
+    let mut app = make_app_at(&tmp);
+    let idx = app
+        .entries
+        .iter()
+        .position(|e| e.name == "big.txt")
+        .unwrap();
+    app.selected = idx;
+    app.load_preview();
+    app.preview_scroll = 5;
+    app.scroll_preview_up(3);
+    assert_eq!(app.preview_scroll, 2);
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+/// Given: preview_scroll is 0
+/// When: scroll_preview_up(5) is called
+/// Then: preview_scroll stays at 0 (no underflow)
+#[test]
+fn scroll_preview_up_at_top_does_not_underflow() {
+    let tmp = std::env::temp_dir().join(format!("trek_pscroll_top_{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&tmp);
+    std::fs::write(tmp.join("f.txt"), b"hello\nworld\n").unwrap();
+    let mut app = make_app_at(&tmp);
+    let idx = app.entries.iter().position(|e| e.name == "f.txt").unwrap();
+    app.selected = idx;
+    app.load_preview();
+    app.preview_scroll = 0;
+    app.scroll_preview_up(5);
+    assert_eq!(app.preview_scroll, 0);
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+/// Given: preview_scroll is already at or near max
+/// When: scroll_preview_down(100) is called
+/// Then: preview_scroll does not exceed preview_lines.len() - 1
+#[test]
+fn scroll_preview_down_at_bottom_clamps() {
+    let tmp = std::env::temp_dir().join(format!("trek_pscroll_bot_{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&tmp);
+    let content: String = (1..=10).map(|i| format!("line {}\n", i)).collect();
+    std::fs::write(tmp.join("short.txt"), content.as_bytes()).unwrap();
+    let mut app = make_app_at(&tmp);
+    let idx = app
+        .entries
+        .iter()
+        .position(|e| e.name == "short.txt")
+        .unwrap();
+    app.selected = idx;
+    app.load_preview();
+    let max = app.preview_lines.len().saturating_sub(1);
+    app.scroll_preview_down(100);
+    assert_eq!(app.preview_scroll, max);
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+/// Given: an empty preview (no file selected / empty file)
+/// When: scroll_preview_down and scroll_preview_up are called
+/// Then: no panic; preview_scroll stays at 0
+#[test]
+fn scroll_preview_on_empty_preview_is_noop() {
+    let tmp = std::env::temp_dir().join(format!("trek_pscroll_empty_{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&tmp);
+    std::fs::write(tmp.join("empty.txt"), b"").unwrap();
+    let mut app = make_app_at(&tmp);
+    app.preview_lines.clear();
+    app.preview_scroll = 0;
+    app.scroll_preview_down(5);
+    app.scroll_preview_up(5);
+    assert_eq!(app.preview_scroll, 0);
+    let _ = std::fs::remove_dir_all(&tmp);
+}

--- a/src/args.rs
+++ b/src/args.rs
@@ -74,6 +74,7 @@ pub fn print_help() {
     println!("    g           Go to top          G           Go to bottom");
     println!("    ~           Go to home         .           Toggle hidden files");
     println!("    e           Jump to typed path (absolute, relative, or ~/…)");
+    println!("    [           Scroll preview up 5 lines  ]  Scroll preview down 5 lines");
     println!("    /           Fuzzy search       Ctrl+F      Content search (rg)");
     println!("    y / Y       Yank relative / absolute path");
     println!("    i           Toggle gitignore filter (hide .gitignored files)");

--- a/src/events.rs
+++ b/src/events.rs
@@ -268,6 +268,9 @@ pub fn run(
                                 }
                             }
                         }
+                        // Preview pane scroll
+                        KeyCode::Char('[') => app.scroll_preview_up(5),
+                        KeyCode::Char(']') => app.scroll_preview_down(5),
                         // Path jump bar
                         KeyCode::Char('e') => app.begin_path_jump(),
                         // Open command palette
@@ -382,6 +385,8 @@ fn execute_palette_action(
         ActionId::ToggleSortOrder => app.toggle_sort_order(),
         ActionId::YankRelativePath => app.yank_relative_path(),
         ActionId::YankAbsolutePath => app.yank_absolute_path(),
+        ActionId::ScrollPreviewUp => app.scroll_preview_up(5),
+        ActionId::ScrollPreviewDown => app.scroll_preview_down(5),
         ActionId::PathJump => app.begin_path_jump(),
         ActionId::ShowHelp => app.show_help = true,
         // Quit appears in the palette for discoverability but cannot break out

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1451,7 +1451,7 @@ fn draw_palette_overlay(f: &mut Frame, app: &App, size: Rect) {
 
 fn draw_help_overlay(f: &mut Frame, size: Rect) {
     let width = 60u16.min(size.width.saturating_sub(4));
-    let height = 56u16.min(size.height.saturating_sub(4));
+    let height = 58u16.min(size.height.saturating_sub(4));
     let x = (size.width.saturating_sub(width)) / 2;
     let y = (size.height.saturating_sub(height)) / 2;
     let area = Rect::new(x, y, width, height);
@@ -1470,6 +1470,7 @@ fn draw_help_overlay(f: &mut Frame, size: Rect) {
         key_line("~", "Go to home directory"),
         key_line(".", "Toggle hidden files"),
         key_line("e", "Jump to path (type any absolute/relative path)"),
+        key_line("[ / ]", "Scroll preview pane up / down (5 lines)"),
         key_line("Ctrl+O", "Go back in directory history"),
         key_line("Ctrl+I", "Go forward in directory history"),
         Line::from(""),


### PR DESCRIPTION
## Summary

- Adds `[` and `]` to scroll the preview pane up/down 5 lines per keypress in normal mode
- Fills the usability gap where mouse wheel scrolled the preview but no keyboard binding existed
- Works in all preview modes: raw content, syntax-highlighted, diff preview, metadata view, directory child listings
- `[` clamps at scroll 0; `]` clamps at last line — no panics on boundary or empty previews
- Navigating to a new file resets preview scroll to 0 (no regression)
- `[`/`]` registered in command palette and documented in help overlay and `--help`
- Bumps version to v0.23.0

## Test plan

- [x] 5 new unit tests: down advances offset, up decreases offset, top boundary clamps, bottom boundary clamps, empty preview is no-op
- [x] All 141 tests pass
- [x] `cargo fmt`, `cargo clippy -- -D warnings`, `cargo build --release` all clean

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)