### PR TITLE
feat(fileops): touch file creation via t key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.24.0] - 2026-03-24
+
+### Added
+- **`t` — touch / new file**: opens an inline `New file:` input bar at the bottom; typing a filename and pressing Enter creates a new empty file in the current directory using `create_new(true)` (atomic, no silent overwrites); the listing refreshes and the cursor selects the newly created file; status bar shows `Created "filename"`
+- Empty filename shows "File name cannot be empty" and closes the bar; attempting to create a file that already exists shows `"'name' already exists"` without overwriting; other filesystem errors are surfaced as readable status messages
+- `t` in the `pending_delete` confirmation branch still confirms trash — no conflict, as that branch runs before normal mode
+- New `pub fn touch_file(parent: &Path, name: &str) -> Result<PathBuf>` in `src/ops.rs` using `OpenOptions::create_new(true)` for atomicity
+- `t` registered in the command palette as "New file (touch — create empty file)"
+- `t` documented in help overlay (`?`) under File Operations alongside `M` and in `--help` output
+- 6 new unit tests: open bar, cancel without creating, create and select, empty name error, existing file error, push/pop char
+
 ## [0.23.0] - 2026-03-24
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trek"
-version = "0.23.0"
+version = "0.24.0"
 edition = "2021"
 rust-version = "1.80"
 description = "A terminal file manager with mouse-resizable panes"

--- a/src/app/file_ops.rs
+++ b/src/app/file_ops.rs
@@ -221,6 +221,55 @@ impl App {
         self.status_message = Some("Delete cancelled".to_string());
     }
 
+    /// Enter touch mode.
+    pub fn begin_touch(&mut self) {
+        self.touch_mode = true;
+        self.touch_input.clear();
+    }
+
+    /// Cancel touch mode without creating anything.
+    pub fn cancel_touch(&mut self) {
+        self.touch_mode = false;
+        self.touch_input.clear();
+    }
+
+    /// Execute touch with the current input and exit touch mode.
+    pub fn confirm_touch(&mut self) {
+        let name = self.touch_input.trim().to_string();
+        self.touch_mode = false;
+        self.touch_input.clear();
+        if name.is_empty() {
+            self.status_message = Some("File name cannot be empty".to_string());
+            return;
+        }
+        match ops::touch_file(&self.cwd, &name) {
+            Ok(_) => {
+                self.status_message = Some(format!("Created \"{}\"", name));
+                self.load_dir();
+                if let Some(idx) = self.entries.iter().position(|e| e.name == name) {
+                    self.selected = idx;
+                    self.load_preview();
+                }
+            }
+            Err(e) => {
+                let msg = if e.to_string().contains("exists") {
+                    format!("'{}' already exists", name)
+                } else {
+                    format!("touch failed: {}", e)
+                };
+                self.status_message = Some(msg);
+            }
+        }
+    }
+
+    pub fn touch_push_char(&mut self, c: char) {
+        self.touch_input.push(c);
+    }
+
+    pub fn touch_pop_char(&mut self) {
+        self.touch_input.pop();
+    }
+
     /// Enter mkdir mode.
     pub fn begin_mkdir(&mut self) {
         self.mkdir_mode = true;

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -286,6 +286,12 @@ pub struct App {
     pub path_mode: bool,
     /// The path string the user is typing in the path jump bar.
     pub path_input: String,
+
+    // --- Touch / new file (t) ---
+    /// True while the touch filename input bar is open.
+    pub touch_mode: bool,
+    /// Filename typed by the user in touch mode.
+    pub touch_input: String,
 }
 
 #[derive(Clone)]
@@ -387,6 +393,8 @@ impl App {
             gitignored_names: std::collections::HashSet::new(),
             path_mode: false,
             path_input: String::new(),
+            touch_mode: false,
+            touch_input: String::new(),
         };
         app.load_dir();
         Ok(app)

--- a/src/app/palette.rs
+++ b/src/app/palette.rs
@@ -27,6 +27,7 @@ pub enum ActionId {
     BeginDeleteCurrent,
     BeginDeleteSelected,
     BeginMkdir,
+    BeginTouch,
     UndoTrash,
     BeginChmod,
     SelectMoveDown,
@@ -163,6 +164,11 @@ pub static PALETTE_ACTIONS: &[PaletteAction] = &[
         id: ActionId::BeginMkdir,
         name: "New directory",
         keys: "M",
+    },
+    PaletteAction {
+        id: ActionId::BeginTouch,
+        name: "New file (touch — create empty file)",
+        keys: "t",
     },
     PaletteAction {
         id: ActionId::UndoTrash,

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -1394,3 +1394,123 @@ fn scroll_preview_on_empty_preview_is_noop() {
     assert_eq!(app.preview_scroll, 0);
     let _ = std::fs::remove_dir_all(&tmp);
 }
+
+// ── touch file (t) tests ──────────────────────────────────────────────────────
+
+/// Given: normal mode
+/// When: begin_touch() is called
+/// Then: touch_mode is true, touch_input is empty
+#[test]
+fn begin_touch_opens_bar() {
+    let tmp = std::env::temp_dir().join(format!("trek_touch_open_{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&tmp);
+    let mut app = make_app_at(&tmp);
+    assert!(!app.touch_mode);
+    app.begin_touch();
+    assert!(app.touch_mode);
+    assert!(app.touch_input.is_empty());
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+/// Given: touch mode open with some input
+/// When: cancel_touch() is called
+/// Then: touch_mode is false, input cleared, no file created
+#[test]
+fn cancel_touch_closes_without_creating() {
+    let tmp = std::env::temp_dir().join(format!("trek_touch_cancel_{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&tmp);
+    let mut app = make_app_at(&tmp);
+    app.begin_touch();
+    app.touch_push_char('f');
+    app.touch_push_char('o');
+    app.touch_push_char('o');
+    app.cancel_touch();
+    assert!(!app.touch_mode);
+    assert!(app.touch_input.is_empty());
+    assert!(
+        !tmp.join("foo").exists(),
+        "no file should be created on cancel"
+    );
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+/// Given: touch mode with a valid filename
+/// When: confirm_touch() is called
+/// Then: file is created, listing refreshed, cursor on new file, status set
+#[test]
+fn confirm_touch_creates_file_and_selects_it() {
+    let tmp = std::env::temp_dir().join(format!("trek_touch_create_{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&tmp);
+    let mut app = make_app_at(&tmp);
+    app.begin_touch();
+    for c in "newfile.txt".chars() {
+        app.touch_push_char(c);
+    }
+    app.confirm_touch();
+    assert!(!app.touch_mode, "touch mode should close after confirm");
+    let created = tmp.join("newfile.txt");
+    assert!(created.exists(), "file should exist on disk");
+    assert_eq!(created.metadata().unwrap().len(), 0, "file should be empty");
+    let selected_name = app.entries.get(app.selected).map(|e| e.name.as_str());
+    assert_eq!(
+        selected_name,
+        Some("newfile.txt"),
+        "cursor should be on new file"
+    );
+    assert!(app.status_message.is_some());
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+/// Given: touch mode with an empty filename
+/// When: confirm_touch() is called
+/// Then: no file created, status message set, touch_mode closed
+#[test]
+fn confirm_touch_empty_name_shows_error() {
+    let tmp = std::env::temp_dir().join(format!("trek_touch_empty_{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&tmp);
+    let mut app = make_app_at(&tmp);
+    app.begin_touch();
+    app.confirm_touch();
+    assert!(!app.touch_mode);
+    assert!(app.status_message.is_some());
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+/// Given: a file already exists with that name
+/// When: confirm_touch() is called with the same name
+/// Then: no overwrite, status message contains the filename
+#[test]
+fn confirm_touch_existing_file_shows_error() {
+    let tmp = std::env::temp_dir().join(format!("trek_touch_exists_{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&tmp);
+    std::fs::write(tmp.join("existing.txt"), b"data").unwrap();
+    let mut app = make_app_at(&tmp);
+    app.begin_touch();
+    for c in "existing.txt".chars() {
+        app.touch_push_char(c);
+    }
+    app.confirm_touch();
+    assert!(!app.touch_mode);
+    assert!(app.status_message.is_some());
+    // Original file content must be preserved
+    assert_eq!(std::fs::read(tmp.join("existing.txt")).unwrap(), b"data");
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+/// Given: touch_input has characters
+/// When: touch_pop_char() is called
+/// Then: last character is removed
+#[test]
+fn touch_push_pop_char() {
+    let tmp = std::env::temp_dir().join(format!("trek_touch_chars_{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&tmp);
+    let mut app = make_app_at(&tmp);
+    app.begin_touch();
+    app.touch_push_char('a');
+    app.touch_push_char('b');
+    app.touch_push_char('c');
+    assert_eq!(app.touch_input, "abc");
+    app.touch_pop_char();
+    assert_eq!(app.touch_input, "ab");
+    let _ = std::fs::remove_dir_all(&tmp);
+}

--- a/src/args.rs
+++ b/src/args.rs
@@ -87,7 +87,8 @@ pub fn print_help() {
     println!("    c           Copy current to clipboard C          Copy selected to clipboard");
     println!("    x           Cut current to clipboard");
     println!("    p           Paste clipboard       Delete      Delete current file/dir");
-    println!("    X           Delete all selected   M           Make new directory");
+    println!("    t           New empty file         M           Make new directory");
+    println!("    X           Delete all selected");
     println!("    :           Open command palette");
     println!("    ?           Show help overlay  q           Quit");
 }

--- a/src/events.rs
+++ b/src/events.rs
@@ -59,6 +59,14 @@ pub fn run(
                         KeyCode::Char(c) => app.mkdir_push_char(c),
                         _ => {}
                     }
+                } else if app.touch_mode {
+                    match key.code {
+                        KeyCode::Esc => app.cancel_touch(),
+                        KeyCode::Enter => app.confirm_touch(),
+                        KeyCode::Backspace => app.touch_pop_char(),
+                        KeyCode::Char(c) => app.touch_push_char(c),
+                        _ => {}
+                    }
                 } else if app.content_search_mode {
                     match key.code {
                         KeyCode::Esc => app.cancel_content_search(),
@@ -219,6 +227,7 @@ pub fn run(
                         KeyCode::Delete => app.begin_delete_current(),
                         KeyCode::Char('X') => app.begin_delete_selected(),
                         KeyCode::Char('M') => app.begin_mkdir(),
+                        KeyCode::Char('t') => app.begin_touch(),
                         // Quick single-file rename
                         KeyCode::Char('n') | KeyCode::F(2) => app.begin_quick_rename(),
                         KeyCode::Char('u') => app.undo_trash(),
@@ -367,6 +376,7 @@ fn execute_palette_action(
         ActionId::BeginDeleteCurrent => app.begin_delete_current(),
         ActionId::BeginDeleteSelected => app.begin_delete_selected(),
         ActionId::BeginMkdir => app.begin_mkdir(),
+        ActionId::BeginTouch => app.begin_touch(),
         ActionId::UndoTrash => app.undo_trash(),
         ActionId::BeginChmod => app.begin_chmod(),
         ActionId::SelectMoveDown => app.select_move_down(),

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -82,6 +82,20 @@ pub fn make_dir(parent: &Path, name: &str) -> Result<PathBuf> {
     Ok(path)
 }
 
+/// Create a new empty file named `name` inside `parent`.
+///
+/// Returns the created path. Fails if a file with that name already exists,
+/// preventing silent overwrites.
+pub fn touch_file(parent: &Path, name: &str) -> Result<PathBuf> {
+    let path = parent.join(name);
+    std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&path)
+        .with_context(|| format!("touch {:?}", path))?;
+    Ok(path)
+}
+
 // ── Tests ──────────────────────────────────────────────────────────────────────
 
 #[cfg(test)]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -103,6 +103,8 @@ pub fn draw(f: &mut Frame, app: &mut App) {
         draw_path_jump_bar(f, app, bottom_area);
     } else if app.mkdir_mode {
         draw_mkdir_bar(f, app, bottom_area);
+    } else if app.touch_mode {
+        draw_touch_bar(f, app, bottom_area);
     } else if app.chmod_mode {
         draw_chmod_bar(f, app, bottom_area);
     } else if app.content_search_mode {
@@ -419,6 +421,29 @@ fn draw_mkdir_bar(f: &mut Frame, app: &App, area: Rect) {
         ),
         Span::styled(
             &app.mkdir_input,
+            Style::default()
+                .fg(Color::White)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled("\u{2588}", Style::default().fg(Color::White)),
+        Span::styled(
+            "  Enter: create   Esc: cancel",
+            Style::default().fg(Color::DarkGray),
+        ),
+    ]));
+    f.render_widget(para, area);
+}
+
+fn draw_touch_bar(f: &mut Frame, app: &App, area: Rect) {
+    let para = Paragraph::new(Line::from(vec![
+        Span::styled(
+            "New file: ",
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(
+            &app.touch_input,
             Style::default()
                 .fg(Color::White)
                 .add_modifier(Modifier::BOLD),
@@ -1451,7 +1476,7 @@ fn draw_palette_overlay(f: &mut Frame, app: &App, size: Rect) {
 
 fn draw_help_overlay(f: &mut Frame, size: Rect) {
     let width = 60u16.min(size.width.saturating_sub(4));
-    let height = 58u16.min(size.height.saturating_sub(4));
+    let height = 60u16.min(size.height.saturating_sub(4));
     let x = (size.width.saturating_sub(width)) / 2;
     let y = (size.height.saturating_sub(height)) / 2;
     let area = Rect::new(x, y, width, height);
@@ -1511,6 +1536,7 @@ fn draw_help_overlay(f: &mut Frame, size: Rect) {
         key_line("p", "Paste clipboard into current dir"),
         key_line("Delete / X", "Trash current / selected (recoverable)"),
         key_line("u", "Undo last trash operation"),
+        key_line("t", "New file (touch — create empty file)"),
         key_line("M", "Make new directory"),
         Line::from(""),
         // ── Yank & Misc ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Adds `t` to open a `New file:` input bar for creating empty files in the current directory
- Uses `OpenOptions::create_new(true)` — atomic, never overwrites an existing file
- Listing refreshes on success and cursor moves to the newly created file
- Error cases: empty name → "File name cannot be empty"; existing file → "'name' already exists"; permission errors → readable message
- `t` in the `pending_delete` confirmation branch still confirms trash (no regression — that branch runs before normal mode)
- New `touch_file()` function in `src/ops.rs`; `begin/confirm/cancel/push/pop_touch` methods in `src/app/file_ops.rs`
- `t` registered in command palette and documented in help overlay and `--help`
- Bumps version to v0.24.0

## Test plan

- [x] 6 new unit tests: open bar, cancel without creating, create and select, empty name error, existing file error, push/pop char
- [x] All 147 tests pass
- [x] `cargo fmt`, `cargo clippy -- -D warnings`, `cargo build --release` all clean

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)