### PR TITLE
feat(preview): toggle line numbers via # key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.25.0] - 2026-03-24
+
+### Added
+- **`#` — preview line numbers**: toggles a numbered gutter in the preview pane; each line is prefixed with its 1-based absolute line number right-justified in a dynamic-width field (`total.to_string().len()` digits) followed by ` │ `; gutter text is `Color::DarkGray` to stay visually recessive
+- Line numbers are correct regardless of scroll offset — the plain-content path uses `enumerate()` before `skip()` for absolute indices; the highlighted path computes `preview_scroll + i + 1` after `skip()` followed by `enumerate()`
+- The toggle persists across file navigation (`show_line_numbers` is a session-level display preference, like `show_hidden`)
+- Works in all preview modes: raw content, syntax-highlighted source, git diff output, metadata card, and directory child listings
+- Status bar shows "Line numbers: on" / "Line numbers: off" on each toggle
+- `#` registered in the command palette as "Toggle line numbers in preview pane"
+- `#` documented in help overlay (`?`) under View and in `--help` output
+- 4 new unit tests: default off, toggle on, toggle off, persists across navigation
+
 ## [0.24.0] - 2026-03-24
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trek"
-version = "0.24.0"
+version = "0.25.0"
 edition = "2021"
 rust-version = "1.80"
 description = "A terminal file manager with mouse-resizable panes"

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -292,6 +292,10 @@ pub struct App {
     pub touch_mode: bool,
     /// Filename typed by the user in touch mode.
     pub touch_input: String,
+
+    // --- Preview line numbers (#) ---
+    /// When true, each preview line is prefixed with its 1-based line number.
+    pub show_line_numbers: bool,
 }
 
 #[derive(Clone)]
@@ -395,6 +399,7 @@ impl App {
             path_input: String::new(),
             touch_mode: false,
             touch_input: String::new(),
+            show_line_numbers: false,
         };
         app.load_dir();
         Ok(app)

--- a/src/app/navigation.rs
+++ b/src/app/navigation.rs
@@ -217,6 +217,16 @@ impl App {
         self.history_pos
     }
 
+    /// Toggle line numbers in the preview pane.
+    pub fn toggle_line_numbers(&mut self) {
+        self.show_line_numbers = !self.show_line_numbers;
+        self.status_message = Some(if self.show_line_numbers {
+            "Line numbers: on".to_string()
+        } else {
+            "Line numbers: off".to_string()
+        });
+    }
+
     // --- Path jump bar (e) ---
 
     /// Open the path jump input bar with an empty input.

--- a/src/app/palette.rs
+++ b/src/app/palette.rs
@@ -43,6 +43,7 @@ pub enum ActionId {
     ToggleSortOrder,
     YankRelativePath,
     YankAbsolutePath,
+    ToggleLineNumbers,
     ScrollPreviewUp,
     ScrollPreviewDown,
     PathJump,
@@ -244,6 +245,11 @@ pub static PALETTE_ACTIONS: &[PaletteAction] = &[
         id: ActionId::YankAbsolutePath,
         name: "Yank absolute path to clipboard",
         keys: "Y",
+    },
+    PaletteAction {
+        id: ActionId::ToggleLineNumbers,
+        name: "Toggle line numbers in preview pane",
+        keys: "#",
     },
     PaletteAction {
         id: ActionId::ScrollPreviewUp,

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -1514,3 +1514,72 @@ fn touch_push_pop_char() {
     assert_eq!(app.touch_input, "ab");
     let _ = std::fs::remove_dir_all(&tmp);
 }
+
+// ── preview line numbers (#) tests ───────────────────────────────────────────
+
+/// Given: default state
+/// When: show_line_numbers is checked
+/// Then: it is false (off by default)
+#[test]
+fn line_numbers_default_off() {
+    let tmp = std::env::temp_dir().join(format!("trek_ln_default_{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&tmp);
+    let app = make_app_at(&tmp);
+    assert!(
+        !app.show_line_numbers,
+        "line numbers should be off by default"
+    );
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+/// Given: show_line_numbers is false
+/// When: toggle_line_numbers() is called
+/// Then: show_line_numbers is true and status message is set
+#[test]
+fn toggle_line_numbers_turns_on() {
+    let tmp = std::env::temp_dir().join(format!("trek_ln_on_{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&tmp);
+    let mut app = make_app_at(&tmp);
+    app.toggle_line_numbers();
+    assert!(app.show_line_numbers);
+    assert!(app.status_message.is_some());
+    let msg = app.status_message.as_deref().unwrap_or("");
+    assert!(msg.contains("on"), "status should say 'on': {}", msg);
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+/// Given: show_line_numbers is true
+/// When: toggle_line_numbers() is called again
+/// Then: show_line_numbers is false and status message reflects off
+#[test]
+fn toggle_line_numbers_turns_off() {
+    let tmp = std::env::temp_dir().join(format!("trek_ln_off_{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&tmp);
+    let mut app = make_app_at(&tmp);
+    app.show_line_numbers = true;
+    app.toggle_line_numbers();
+    assert!(!app.show_line_numbers);
+    let msg = app.status_message.as_deref().unwrap_or("");
+    assert!(msg.contains("off"), "status should say 'off': {}", msg);
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+/// Given: show_line_numbers persists across file navigation
+/// When: toggle then navigate to another file with j (move_down)
+/// Then: show_line_numbers is still true
+#[test]
+fn line_numbers_persist_across_navigation() {
+    let tmp = std::env::temp_dir().join(format!("trek_ln_nav_{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&tmp);
+    std::fs::write(tmp.join("a.txt"), b"line1\n").unwrap();
+    std::fs::write(tmp.join("b.txt"), b"line1\nline2\n").unwrap();
+    let mut app = make_app_at(&tmp);
+    app.toggle_line_numbers();
+    assert!(app.show_line_numbers);
+    app.move_down();
+    assert!(
+        app.show_line_numbers,
+        "show_line_numbers should persist after navigation"
+    );
+    let _ = std::fs::remove_dir_all(&tmp);
+}

--- a/src/args.rs
+++ b/src/args.rs
@@ -77,6 +77,7 @@ pub fn print_help() {
     println!("    [           Scroll preview up 5 lines  ]  Scroll preview down 5 lines");
     println!("    /           Fuzzy search       Ctrl+F      Content search (rg)");
     println!("    y / Y       Yank relative / absolute path");
+    println!("    #           Toggle line numbers in preview pane");
     println!("    i           Toggle gitignore filter (hide .gitignored files)");
     println!("    d           Toggle diff preview R           Refresh git status");
     println!("    J           Extend selection down  K           Extend selection up");

--- a/src/events.rs
+++ b/src/events.rs
@@ -277,9 +277,10 @@ pub fn run(
                                 }
                             }
                         }
-                        // Preview pane scroll
+                        // Preview pane scroll and display
                         KeyCode::Char('[') => app.scroll_preview_up(5),
                         KeyCode::Char(']') => app.scroll_preview_down(5),
+                        KeyCode::Char('#') => app.toggle_line_numbers(),
                         // Path jump bar
                         KeyCode::Char('e') => app.begin_path_jump(),
                         // Open command palette
@@ -395,6 +396,7 @@ fn execute_palette_action(
         ActionId::ToggleSortOrder => app.toggle_sort_order(),
         ActionId::YankRelativePath => app.yank_relative_path(),
         ActionId::YankAbsolutePath => app.yank_absolute_path(),
+        ActionId::ToggleLineNumbers => app.toggle_line_numbers(),
         ActionId::ScrollPreviewUp => app.scroll_preview_up(5),
         ActionId::ScrollPreviewDown => app.scroll_preview_down(5),
         ActionId::PathJump => app.begin_path_jump(),

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -705,21 +705,50 @@ fn draw_preview_pane(f: &mut Frame, app: &App, area: Rect) {
         None
     };
 
+    let gutter_width = if app.show_line_numbers && total > 0 {
+        total.to_string().len()
+    } else {
+        0
+    };
+
     let lines: Vec<Line> = if let Some(hl) = highlighted {
         hl.into_iter()
             .skip(app.preview_scroll)
+            .enumerate()
             .take(visible_height)
+            .map(|(i, line)| {
+                if app.show_line_numbers {
+                    let abs_line = app.preview_scroll + i + 1;
+                    let gutter = format!("{:>width$} \u{2502} ", abs_line, width = gutter_width);
+                    let gutter_span = Span::styled(gutter, Style::default().fg(Color::DarkGray));
+                    let mut spans = vec![gutter_span];
+                    spans.extend(line.spans);
+                    Line::from(spans)
+                } else {
+                    line
+                }
+            })
             .collect()
     } else {
         app.preview_lines
             .iter()
+            .enumerate()
             .skip(app.preview_scroll)
             .take(visible_height)
-            .map(|l| {
-                if app.preview_is_diff {
+            .map(|(i, l)| {
+                let content_line = if app.preview_is_diff {
                     colorize_diff_line(l)
                 } else {
                     Line::from(l.as_str())
+                };
+                if app.show_line_numbers {
+                    let gutter = format!("{:>width$} \u{2502} ", i + 1, width = gutter_width);
+                    let gutter_span = Span::styled(gutter, Style::default().fg(Color::DarkGray));
+                    let mut spans = vec![gutter_span];
+                    spans.extend(content_line.spans);
+                    Line::from(spans)
+                } else {
+                    content_line
                 }
             })
             .collect()
@@ -1476,7 +1505,7 @@ fn draw_palette_overlay(f: &mut Frame, app: &App, size: Rect) {
 
 fn draw_help_overlay(f: &mut Frame, size: Rect) {
     let width = 60u16.min(size.width.saturating_sub(4));
-    let height = 60u16.min(size.height.saturating_sub(4));
+    let height = 62u16.min(size.height.saturating_sub(4));
     let x = (size.width.saturating_sub(width)) / 2;
     let y = (size.height.saturating_sub(height)) / 2;
     let area = Rect::new(x, y, width, height);
@@ -1510,6 +1539,7 @@ fn draw_help_overlay(f: &mut Frame, size: Rect) {
         Line::from(""),
         // ── View ────────────────────────────────────────────────────────────
         section_header("View"),
+        key_line("#", "Toggle line numbers in preview pane"),
         key_line("i", "Toggle gitignore filter (hide ignored files)"),
         key_line("d", "Toggle git diff preview"),
         key_line("m", "Toggle file metadata view"),


### PR DESCRIPTION
## Summary

- Adds `#` to toggle a numbered gutter in the preview pane
- Dynamic gutter width — `total.to_string().len()` digits, so short files use 1-2 chars and large files grow automatically; no fixed 4-wide waste
- Line numbers are 1-based absolute, correct at any scroll offset:
  - Plain/diff path: `enumerate()` **before** `skip()` so `i` is the absolute 0-based index
  - Highlighted path: `preview_scroll + i + 1` after `skip()` + `enumerate()`
- Gutter uses `Color::DarkGray` to stay visually recessive; separator is ` │ `
- Toggle persists across navigation (`show_line_numbers` is a session-level preference like `show_hidden`)
- Works in all preview modes: raw, syntax-highlighted, diff, metadata, directory listing
- Status bar shows "Line numbers: on" / "Line numbers: off"
- `#` registered in command palette and documented in help overlay and `--help`
- Bumps version to v0.25.0

## Test plan

- [x] 4 new unit tests: default off, toggle on (status = "on"), toggle off (status = "off"), persists across navigation
- [x] All 151 tests pass
- [x] `cargo fmt`, `cargo clippy -- -D warnings`, `cargo build --release` all clean

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)