### PR TITLE
feat(glob): add glob pattern selection (*) for bulk file operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.26.0] - 2026-03-24
+
+### Added
+- **`*` — glob pattern selection**: opens an inline `Glob select:` input bar at the bottom (Magenta label); typing a glob pattern (e.g. `*.rs`, `*.log`, `test_?`) and pressing Enter adds all matching files in the current directory to the rename selection set (`rename_selected`); union semantics — multiple patterns can be chained without losing prior selections
+- `*` matches any sequence of characters (including empty); `?` matches exactly one character; all other characters (including `.`) are regex-escaped so `*.tar.gz` matches literal dots, not "any character"
+- Non-matching patterns display "No entries match: `<pattern>`" in the status bar; the bar closes regardless; directories are always excluded from matches
+- Empty pattern silently closes the bar (no-op); malformed patterns (invalid after glob→regex conversion) display "Invalid glob pattern: `<pattern>`"
+- Glob→regex conversion implemented as `glob_to_regex()` (private free function in `src/app/rename.rs`) using `regex::escape` for non-metacharacters — no new crate dependencies
+- `*` registered in the command palette as "Select files by glob pattern"
+- `*` documented in help overlay (`?`) under Selection & Rename and in `--help` output
+- 8 new unit tests: open bar, cancel without selecting, extension match, no-match message, union-add semantics, empty pattern noop, `?` single-char match, literal-dot handling
+
 ## [0.25.0] - 2026-03-24
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -586,7 +586,7 @@ dependencies = [
 
 [[package]]
 name = "trek"
-version = "0.20.0"
+version = "0.26.0"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trek"
-version = "0.25.0"
+version = "0.26.0"
 edition = "2021"
 rust-version = "1.80"
 description = "A terminal file manager with mouse-resizable panes"

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -296,6 +296,12 @@ pub struct App {
     // --- Preview line numbers (#) ---
     /// When true, each preview line is prefixed with its 1-based line number.
     pub show_line_numbers: bool,
+
+    // --- Glob pattern selection (*) ---
+    /// True while the glob pattern input bar is open.
+    pub glob_mode: bool,
+    /// Glob pattern typed by the user.
+    pub glob_input: String,
 }
 
 #[derive(Clone)]
@@ -400,6 +406,8 @@ impl App {
             touch_mode: false,
             touch_input: String::new(),
             show_line_numbers: false,
+            glob_mode: false,
+            glob_input: String::new(),
         };
         app.load_dir();
         Ok(app)

--- a/src/app/palette.rs
+++ b/src/app/palette.rs
@@ -47,6 +47,7 @@ pub enum ActionId {
     ScrollPreviewUp,
     ScrollPreviewDown,
     PathJump,
+    GlobSelect,
     ShowHelp,
     Quit,
 }
@@ -265,6 +266,11 @@ pub static PALETTE_ACTIONS: &[PaletteAction] = &[
         id: ActionId::PathJump,
         name: "Jump to path (path jump bar)",
         keys: "e",
+    },
+    PaletteAction {
+        id: ActionId::GlobSelect,
+        name: "Select files by glob pattern",
+        keys: "*",
     },
     PaletteAction {
         id: ActionId::ShowHelp,

--- a/src/app/rename.rs
+++ b/src/app/rename.rs
@@ -3,6 +3,25 @@ use crate::rename::{self, RenameField};
 use std::fs;
 use std::path::PathBuf;
 
+/// Convert a simple glob pattern (`*`, `?` metacharacters) to a full-match regex string.
+///
+/// - `*`  matches any sequence of characters (including empty).
+/// - `?`  matches exactly one character.
+/// - All other characters are regex-escaped so that `.` in `*.tar.gz` matches a
+///   literal dot and not "any character".
+fn glob_to_regex(pattern: &str) -> String {
+    let mut re = String::from("^");
+    for ch in pattern.chars() {
+        match ch {
+            '*' => re.push_str(".*"),
+            '?' => re.push('.'),
+            c => re.push_str(&regex::escape(&c.to_string())),
+        }
+    }
+    re.push('$');
+    re
+}
+
 impl App {
     /// Toggle the rename-selection mark on entry `idx`.
     ///
@@ -174,6 +193,75 @@ impl App {
         );
         self.rename_preview = preview;
         self.rename_error = error;
+    }
+
+    // --- Glob pattern selection (*) ---
+
+    /// Open the glob pattern input bar.
+    pub fn begin_glob_select(&mut self) {
+        self.glob_mode = true;
+        self.glob_input.clear();
+    }
+
+    /// Close the glob bar without modifying the selection.
+    pub fn cancel_glob_select(&mut self) {
+        self.glob_mode = false;
+        self.glob_input.clear();
+    }
+
+    /// Apply the glob pattern and add matching entries to `rename_selected`.
+    ///
+    /// - Empty pattern → silently close the bar (no-op).
+    /// - Non-matching pattern → show a status message; keep bar closed.
+    /// - Matching pattern → union-add matched indices and close the bar.
+    pub fn confirm_glob_select(&mut self) {
+        if self.glob_input.is_empty() {
+            self.glob_mode = false;
+            return;
+        }
+
+        let pattern = self.glob_input.clone();
+        let re_str = glob_to_regex(&pattern);
+        let re = match regex::Regex::new(&re_str) {
+            Ok(r) => r,
+            Err(_) => {
+                self.status_message = Some(format!("Invalid glob pattern: {pattern}"));
+                self.glob_mode = false;
+                self.glob_input.clear();
+                return;
+            }
+        };
+
+        let matched: Vec<usize> = self
+            .entries
+            .iter()
+            .enumerate()
+            .filter(|(_, e)| !e.is_dir && re.is_match(&e.name))
+            .map(|(i, _)| i)
+            .collect();
+
+        if matched.is_empty() {
+            self.status_message = Some(format!("No entries match: {pattern}"));
+        } else {
+            let count = matched.len();
+            for idx in matched {
+                self.rename_selected.insert(idx);
+            }
+            self.status_message = Some(format!("Selected {count} file(s) matching \"{pattern}\""));
+        }
+
+        self.glob_mode = false;
+        self.glob_input.clear();
+    }
+
+    /// Append a character to the glob pattern input.
+    pub fn glob_push_char(&mut self, c: char) {
+        self.glob_input.push(c);
+    }
+
+    /// Remove the last character from the glob pattern input.
+    pub fn glob_pop_char(&mut self) {
+        self.glob_input.pop();
     }
 
     pub fn read_file_preview(path: &PathBuf) -> Vec<String> {

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -1583,3 +1583,198 @@ fn line_numbers_persist_across_navigation() {
     );
     let _ = std::fs::remove_dir_all(&tmp);
 }
+
+// ── glob pattern selection (*) tests ─────────────────────────────────────────
+
+/// Given: normal mode
+/// When: begin_glob_select() is called
+/// Then: glob_mode is true, glob_input is empty
+#[test]
+fn begin_glob_select_opens_bar() {
+    let tmp = std::env::temp_dir().join(format!("trek_glob_open_{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&tmp);
+    let mut app = make_app_at(&tmp);
+    assert!(!app.glob_mode);
+    app.begin_glob_select();
+    assert!(app.glob_mode);
+    assert!(app.glob_input.is_empty());
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+/// Given: glob mode open with pattern typed
+/// When: cancel_glob_select() is called
+/// Then: glob_mode is false, input cleared, selection unchanged
+#[test]
+fn cancel_glob_select_closes_without_selecting() {
+    let tmp = std::env::temp_dir().join(format!("trek_glob_cancel_{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&tmp);
+    std::fs::write(tmp.join("a.rs"), b"").unwrap();
+    let mut app = make_app_at(&tmp);
+    app.begin_glob_select();
+    app.glob_push_char('*');
+    app.glob_push_char('.');
+    app.glob_push_char('r');
+    app.glob_push_char('s');
+    app.cancel_glob_select();
+    assert!(!app.glob_mode);
+    assert!(app.glob_input.is_empty());
+    assert!(
+        app.rename_selected.is_empty(),
+        "selection should be unchanged"
+    );
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+/// Given: directory with mixed files, pattern *.log
+/// When: confirm_glob_select() is called
+/// Then: only .log files are added to rename_selected
+#[test]
+fn confirm_glob_select_matches_extension() {
+    let tmp = std::env::temp_dir().join(format!("trek_glob_ext_{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&tmp);
+    std::fs::write(tmp.join("build.log"), b"").unwrap();
+    std::fs::write(tmp.join("access.log"), b"").unwrap();
+    std::fs::write(tmp.join("main.rs"), b"").unwrap();
+    let mut app = make_app_at(&tmp);
+    app.begin_glob_select();
+    for c in "*.log".chars() {
+        app.glob_push_char(c);
+    }
+    app.confirm_glob_select();
+    assert!(!app.glob_mode);
+    // Exactly 2 entries selected
+    assert_eq!(app.rename_selected.len(), 2);
+    // All selected entries are .log files
+    for &idx in &app.rename_selected {
+        let name = &app.entries[idx].name;
+        assert!(
+            name.ends_with(".log"),
+            "unexpected selected entry: {}",
+            name
+        );
+    }
+    // Status message mentions the count
+    let msg = app.status_message.as_deref().unwrap_or("");
+    assert!(msg.contains("2"), "status should report 2 matches: {}", msg);
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+/// Given: a pattern that matches nothing
+/// When: confirm_glob_select() is called
+/// Then: rename_selected is empty, status message says no matches
+#[test]
+fn confirm_glob_select_no_match_shows_message() {
+    let tmp = std::env::temp_dir().join(format!("trek_glob_nomatch_{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&tmp);
+    std::fs::write(tmp.join("main.rs"), b"").unwrap();
+    let mut app = make_app_at(&tmp);
+    app.begin_glob_select();
+    for c in "*.xyz".chars() {
+        app.glob_push_char(c);
+    }
+    app.confirm_glob_select();
+    assert!(app.rename_selected.is_empty());
+    let msg = app.status_message.as_deref().unwrap_or("");
+    assert!(
+        msg.contains("No") || msg.contains("no"),
+        "status should say no matches: {}",
+        msg
+    );
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+/// Given: some entries already selected
+/// When: confirm_glob_select() is called with a new pattern
+/// Then: new matches are ADDED to the existing selection (union)
+#[test]
+fn confirm_glob_select_adds_to_existing_selection() {
+    let tmp = std::env::temp_dir().join(format!("trek_glob_union_{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&tmp);
+    std::fs::write(tmp.join("a.log"), b"").unwrap();
+    std::fs::write(tmp.join("b.rs"), b"").unwrap();
+    let mut app = make_app_at(&tmp);
+    // Pre-select the first entry
+    app.rename_selected.insert(0);
+    app.begin_glob_select();
+    // Pattern that matches the second entry only
+    for c in "*.rs".chars() {
+        app.glob_push_char(c);
+    }
+    app.confirm_glob_select();
+    // Both should now be selected
+    assert_eq!(
+        app.rename_selected.len(),
+        2,
+        "both entries should be selected"
+    );
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+/// Given: an empty pattern
+/// When: confirm_glob_select() is called
+/// Then: selection is unchanged, bar closes silently
+#[test]
+fn confirm_glob_select_empty_pattern_is_noop() {
+    let tmp = std::env::temp_dir().join(format!("trek_glob_empty_{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&tmp);
+    std::fs::write(tmp.join("file.txt"), b"").unwrap();
+    let mut app = make_app_at(&tmp);
+    app.begin_glob_select();
+    app.confirm_glob_select(); // empty input
+    assert!(!app.glob_mode);
+    assert!(app.rename_selected.is_empty());
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+/// glob_to_regex tests (via confirm_glob_select behaviour)
+
+/// Given: pattern "test_?" (? = single char)
+/// When: confirm_glob_select() is called
+/// Then: "test_a" matches but "test_ab" does not
+#[test]
+fn glob_question_mark_matches_single_char() {
+    let tmp = std::env::temp_dir().join(format!("trek_glob_q_{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&tmp);
+    std::fs::write(tmp.join("test_a"), b"").unwrap();
+    std::fs::write(tmp.join("test_ab"), b"").unwrap();
+    std::fs::write(tmp.join("other"), b"").unwrap();
+    let mut app = make_app_at(&tmp);
+    app.begin_glob_select();
+    for c in "test_?".chars() {
+        app.glob_push_char(c);
+    }
+    app.confirm_glob_select();
+    assert_eq!(app.rename_selected.len(), 1, "only test_a should match");
+    let matched_name = app.entries[*app.rename_selected.iter().next().unwrap()]
+        .name
+        .clone();
+    assert_eq!(matched_name, "test_a");
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+/// Given: pattern "*.tar.gz" (literal dots must not be regex wildcards)
+/// When: confirm_glob_select() is called
+/// Then: "archive.tar.gz" matches but "archiveXtarYgz" does not
+#[test]
+fn glob_dots_are_literal_not_regex_wildcards() {
+    let tmp = std::env::temp_dir().join(format!("trek_glob_dot_{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&tmp);
+    std::fs::write(tmp.join("archive.tar.gz"), b"").unwrap();
+    std::fs::write(tmp.join("archiveXtarYgz"), b"").unwrap();
+    let mut app = make_app_at(&tmp);
+    app.begin_glob_select();
+    for c in "*.tar.gz".chars() {
+        app.glob_push_char(c);
+    }
+    app.confirm_glob_select();
+    assert_eq!(
+        app.rename_selected.len(),
+        1,
+        "only archive.tar.gz should match"
+    );
+    let matched_name = app.entries[*app.rename_selected.iter().next().unwrap()]
+        .name
+        .clone();
+    assert_eq!(matched_name, "archive.tar.gz");
+    let _ = std::fs::remove_dir_all(&tmp);
+}

--- a/src/args.rs
+++ b/src/args.rs
@@ -82,6 +82,7 @@ pub fn print_help() {
     println!("    d           Toggle diff preview R           Refresh git status");
     println!("    J           Extend selection down  K           Extend selection up");
     println!("    Space       Toggle file selection v          Select all files");
+    println!("    *           Select files by glob pattern (e.g. *.rs, *.log, test_?)");
     println!("    n / F2      Quick rename (inline bar pre-filled with current name)");
     println!("    r           Bulk rename selected files with regex  Esc  Clear selections");
     println!("    o           Open in $EDITOR        O           Open with system default");

--- a/src/events.rs
+++ b/src/events.rs
@@ -148,6 +148,14 @@ pub fn run(
                         KeyCode::Char(c) => app.path_push_char(c),
                         _ => {}
                     }
+                } else if app.glob_mode {
+                    match key.code {
+                        KeyCode::Esc => app.cancel_glob_select(),
+                        KeyCode::Enter => app.confirm_glob_select(),
+                        KeyCode::Backspace => app.glob_pop_char(),
+                        KeyCode::Char(c) => app.glob_push_char(c),
+                        _ => {}
+                    }
                 } else if app.palette_mode {
                     match key.code {
                         KeyCode::Esc | KeyCode::Char(':') => app.close_palette(),
@@ -283,6 +291,8 @@ pub fn run(
                         KeyCode::Char('#') => app.toggle_line_numbers(),
                         // Path jump bar
                         KeyCode::Char('e') => app.begin_path_jump(),
+                        // Glob pattern selection
+                        KeyCode::Char('*') => app.begin_glob_select(),
                         // Open command palette
                         KeyCode::Char(':') => app.open_palette(),
                         // Open with system default (open on macOS, xdg-open on Linux)
@@ -400,6 +410,7 @@ fn execute_palette_action(
         ActionId::ScrollPreviewUp => app.scroll_preview_up(5),
         ActionId::ScrollPreviewDown => app.scroll_preview_down(5),
         ActionId::PathJump => app.begin_path_jump(),
+        ActionId::GlobSelect => app.begin_glob_select(),
         ActionId::ShowHelp => app.show_help = true,
         // Quit appears in the palette for discoverability but cannot break out
         // of the event loop from here — use q directly.

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -101,6 +101,8 @@ pub fn draw(f: &mut Frame, app: &mut App) {
         draw_quick_rename_bar(f, app, bottom_area);
     } else if app.path_mode {
         draw_path_jump_bar(f, app, bottom_area);
+    } else if app.glob_mode {
+        draw_glob_select_bar(f, app, bottom_area);
     } else if app.mkdir_mode {
         draw_mkdir_bar(f, app, bottom_area);
     } else if app.touch_mode {
@@ -451,6 +453,29 @@ fn draw_touch_bar(f: &mut Frame, app: &App, area: Rect) {
         Span::styled("\u{2588}", Style::default().fg(Color::White)),
         Span::styled(
             "  Enter: create   Esc: cancel",
+            Style::default().fg(Color::DarkGray),
+        ),
+    ]));
+    f.render_widget(para, area);
+}
+
+fn draw_glob_select_bar(f: &mut Frame, app: &App, area: Rect) {
+    let para = Paragraph::new(Line::from(vec![
+        Span::styled(
+            "Glob select: ",
+            Style::default()
+                .fg(Color::Magenta)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(
+            &app.glob_input,
+            Style::default()
+                .fg(Color::White)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled("\u{2588}", Style::default().fg(Color::White)),
+        Span::styled(
+            "  Enter: select   Esc: cancel  (e.g. *.rs  *.log  test_?)",
             Style::default().fg(Color::DarkGray),
         ),
     ]));
@@ -1505,7 +1530,7 @@ fn draw_palette_overlay(f: &mut Frame, app: &App, size: Rect) {
 
 fn draw_help_overlay(f: &mut Frame, size: Rect) {
     let width = 60u16.min(size.width.saturating_sub(4));
-    let height = 62u16.min(size.height.saturating_sub(4));
+    let height = 64u16.min(size.height.saturating_sub(4));
     let x = (size.width.saturating_sub(width)) / 2;
     let y = (size.height.saturating_sub(height)) / 2;
     let area = Rect::new(x, y, width, height);
@@ -1553,6 +1578,7 @@ fn draw_help_overlay(f: &mut Frame, size: Rect) {
         key_line("J / K", "Extend selection down / up (range select)"),
         key_line("Space", "Toggle file selection"),
         key_line("v", "Select all files"),
+        key_line("*", "Select files by glob pattern (e.g. *.rs)"),
         key_line("n / F2", "Quick rename (inline bar pre-filled)"),
         key_line("r", "Bulk rename selected files with regex"),
         key_line("Esc", "Clear filter (if active) or selections"),


### PR DESCRIPTION
## Summary

- Adds `*` keybinding that opens an inline `Glob select:` bar (Magenta label) for selecting files by glob pattern
- `*` matches any sequence of chars; `?` matches exactly one; all other chars (including `.`) are regex-escaped, so `*.tar.gz` matches literal dots
- Union semantics: multiple patterns can be chained without losing prior selections; directories always excluded

## Details

- `glob_to_regex()` free function converts globs to full-match regexes using `regex::escape` — no new crate dependencies
- Registered in command palette as "Select files by glob pattern"
- Documented in help overlay (`?`) under Selection & Rename and in `--help` output
- 8 new BDD-style tests (all 159 tests pass): open bar, cancel, extension match, no-match message, union-add, empty noop, `?` single-char, literal-dot

## Test plan

- [ ] `cargo test` — 159 tests pass
- [ ] `cargo clippy -- -D warnings` — clean
- [ ] `cargo build --release` — builds successfully
- [ ] Press `*` in trek → glob bar opens with Magenta label
- [ ] Type `*.rs` → Enter → all `.rs` files selected
- [ ] Type `*.log` → Enter → `.log` files added to existing selection (union)
- [ ] Type `test_?` → files matching single-char suffix selected
- [ ] Type `*.tar.gz` → literal-dot files matched correctly
- [ ] Empty pattern → bar closes silently
- [ ] Non-matching pattern → "No entries match" status

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)