### PR TITLE
feat(file-ops): add in-place file duplication (W)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.27.0] - 2026-03-24
+
+### Added
+- **`W` — duplicate entry in place**: press `W` on any file or directory to open a `Duplicate:` bar (Cyan label) pre-filled with a suggested name; edit the name and press Enter to copy the entry to `cwd/<name>`; the listing refreshes and the cursor moves to the new entry
+- Name suggestion algorithm uses the first dot to preserve compound extensions: `archive.tar.gz` → `archive_copy.tar.gz`; `config.toml` → `config_copy.toml`; `Makefile` → `Makefile_copy`
+- Destination already existing shows `'<name>' already exists` without touching the filesystem; empty name shows "Name cannot be empty"
+- Directories are duplicated recursively via the existing `ops::copy_path` (which already handles recursive directory copy)
+- Success message: `Duplicated → "<name>"`; after success the new entry is selected in the refreshed listing
+- `W` registered in the command palette as "Duplicate entry in place"
+- `W` documented in help overlay (`?`) under File Operations and in `--help` output
+- 8 new BDD-style unit tests covering: open bar with suggested name, cancel, file copy success, existing-name error, empty-name error, compound extension, no-extension, empty-directory noop
+
 ## [0.26.0] - 2026-03-24
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -586,7 +586,7 @@ dependencies = [
 
 [[package]]
 name = "trek"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trek"
-version = "0.26.0"
+version = "0.27.0"
 edition = "2021"
 rust-version = "1.80"
 description = "A terminal file manager with mouse-resizable panes"

--- a/src/app/file_ops.rs
+++ b/src/app/file_ops.rs
@@ -2,6 +2,23 @@ use super::App;
 use crate::ops::{self, Clipboard, ClipboardOp};
 use std::path::PathBuf;
 
+/// Suggest a duplicate name for `name` by inserting `_copy` before the last extension.
+///
+/// Examples:
+///   "config.toml"    → "config_copy.toml"
+///   "archive.tar.gz" → "archive_copy.tar.gz"  (preserves compound extension)
+///   "Makefile"       → "Makefile_copy"
+fn suggest_dup_name(name: &str) -> String {
+    if let Some(dot) = name.find('.') {
+        if dot > 0 {
+            let stem = &name[..dot];
+            let ext = &name[dot..]; // includes the leading dot and any compound extension
+            return format!("{}_copy{}", stem, ext);
+        }
+    }
+    format!("{}_copy", name)
+}
+
 impl App {
     /// Yank (copy) the currently selected entry to the clipboard.
     pub fn clipboard_copy_current(&mut self) {
@@ -324,5 +341,73 @@ impl App {
             .filter_map(|&i| self.entries.get(i))
             .map(|e| e.path.clone())
             .collect()
+    }
+
+    // --- File duplication (W) ---
+
+    /// Open the duplicate name bar for the currently selected entry.
+    ///
+    /// Pre-fills the input with a suggested name derived from the source name.
+    /// Does nothing if the directory is empty.
+    pub fn begin_dup(&mut self) {
+        if let Some(entry) = self.entries.get(self.selected) {
+            self.dup_src = Some(entry.path.clone());
+            self.dup_input = suggest_dup_name(&entry.name);
+            self.dup_mode = true;
+        }
+    }
+
+    /// Cancel the duplication without touching the filesystem.
+    pub fn cancel_dup(&mut self) {
+        self.dup_mode = false;
+        self.dup_input.clear();
+        self.dup_src = None;
+    }
+
+    /// Execute the duplication with the current input name.
+    ///
+    /// - Empty name → error message, bar closed.
+    /// - Destination already exists → error message, no overwrite.
+    /// - Success → copy created, listing refreshed, new entry selected.
+    pub fn confirm_dup(&mut self) {
+        let name = self.dup_input.trim().to_string();
+        self.dup_mode = false;
+        self.dup_input.clear();
+        let src = match self.dup_src.take() {
+            Some(p) => p,
+            None => return,
+        };
+        if name.is_empty() {
+            self.status_message = Some("Name cannot be empty".to_string());
+            return;
+        }
+        let dst = self.cwd.join(&name);
+        if dst.exists() {
+            self.status_message = Some(format!("'{}' already exists", name));
+            return;
+        }
+        match ops::copy_path(&src, &dst) {
+            Ok(()) => {
+                self.load_dir();
+                if let Some(idx) = self.entries.iter().position(|e| e.name == name) {
+                    self.selected = idx;
+                    self.load_preview();
+                }
+                self.status_message = Some(format!("Duplicated \u{2192} \"{}\"", name));
+            }
+            Err(e) => {
+                self.status_message = Some(format!("Duplicate failed: {}", e));
+            }
+        }
+    }
+
+    /// Append a character to the duplicate name input.
+    pub fn dup_push_char(&mut self, c: char) {
+        self.dup_input.push(c);
+    }
+
+    /// Remove the last character from the duplicate name input.
+    pub fn dup_pop_char(&mut self) {
+        self.dup_input.pop();
     }
 }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -302,6 +302,14 @@ pub struct App {
     pub glob_mode: bool,
     /// Glob pattern typed by the user.
     pub glob_input: String,
+
+    // --- File duplication (W) ---
+    /// True while the duplicate name input bar is open.
+    pub dup_mode: bool,
+    /// Name typed by the user (pre-filled with the suggested name).
+    pub dup_input: String,
+    /// Source path being duplicated; set when dup_mode is entered.
+    pub dup_src: Option<PathBuf>,
 }
 
 #[derive(Clone)]
@@ -408,6 +416,9 @@ impl App {
             show_line_numbers: false,
             glob_mode: false,
             glob_input: String::new(),
+            dup_mode: false,
+            dup_input: String::new(),
+            dup_src: None,
         };
         app.load_dir();
         Ok(app)

--- a/src/app/palette.rs
+++ b/src/app/palette.rs
@@ -48,6 +48,7 @@ pub enum ActionId {
     ScrollPreviewDown,
     PathJump,
     GlobSelect,
+    BeginDup,
     ShowHelp,
     Quit,
 }
@@ -271,6 +272,11 @@ pub static PALETTE_ACTIONS: &[PaletteAction] = &[
         id: ActionId::GlobSelect,
         name: "Select files by glob pattern",
         keys: "*",
+    },
+    PaletteAction {
+        id: ActionId::BeginDup,
+        name: "Duplicate entry in place",
+        keys: "W",
     },
     PaletteAction {
         id: ActionId::ShowHelp,

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -1778,3 +1778,139 @@ fn glob_dots_are_literal_not_regex_wildcards() {
     assert_eq!(matched_name, "archive.tar.gz");
     let _ = std::fs::remove_dir_all(&tmp);
 }
+
+// ── File duplication (W) ────────────────────────────────────────────────────
+
+/// Given: a directory with a file "config.toml"
+/// When: begin_dup is called on that file
+/// Then: dup_mode is true and dup_input is pre-filled with "config_copy.toml"
+#[test]
+fn begin_dup_opens_bar_with_suggested_name() {
+    let tmp = std::env::temp_dir().join(format!("trek_dup_open_{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&tmp);
+    std::fs::write(tmp.join("config.toml"), b"").unwrap();
+    let mut app = make_app_at(&tmp);
+    app.begin_dup();
+    assert!(app.dup_mode, "dup_mode should be true");
+    assert_eq!(app.dup_input, "config_copy.toml");
+    assert!(app.dup_src.is_some(), "dup_src should be set");
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+/// Given: dup_mode is open
+/// When: cancel_dup is called
+/// Then: dup_mode is false, dup_input is cleared, dup_src is None
+#[test]
+fn cancel_dup_closes_without_creating() {
+    let tmp = std::env::temp_dir().join(format!("trek_dup_cancel_{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&tmp);
+    std::fs::write(tmp.join("readme.md"), b"").unwrap();
+    let mut app = make_app_at(&tmp);
+    app.begin_dup();
+    assert!(app.dup_mode);
+    app.cancel_dup();
+    assert!(!app.dup_mode);
+    assert!(app.dup_input.is_empty());
+    assert!(app.dup_src.is_none());
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+/// Given: dup_mode is open with a valid name typed
+/// When: confirm_dup is called
+/// Then: a copy is created in cwd, listing refreshes, new entry is selected
+#[test]
+fn confirm_dup_creates_file_copy() {
+    let tmp = std::env::temp_dir().join(format!("trek_dup_confirm_{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&tmp);
+    std::fs::write(tmp.join("notes.txt"), b"hello").unwrap();
+    let mut app = make_app_at(&tmp);
+    app.begin_dup();
+    app.dup_input = "notes_backup.txt".to_string();
+    app.confirm_dup();
+    assert!(!app.dup_mode);
+    assert!(tmp.join("notes_backup.txt").exists(), "copy should exist");
+    let names: Vec<_> = app.entries.iter().map(|e| e.name.as_str()).collect();
+    assert!(
+        names.contains(&"notes_backup.txt"),
+        "listing should contain the copy"
+    );
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+/// Given: a file "data.csv" exists, dup_input is "data.csv" (same name)
+/// When: confirm_dup is called
+/// Then: no overwrite, status message contains "already exists"
+#[test]
+fn confirm_dup_existing_name_shows_error() {
+    let tmp = std::env::temp_dir().join(format!("trek_dup_existing_{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&tmp);
+    std::fs::write(tmp.join("data.csv"), b"").unwrap();
+    let mut app = make_app_at(&tmp);
+    app.begin_dup();
+    app.dup_input = "data.csv".to_string();
+    app.confirm_dup();
+    let msg = app.status_message.unwrap_or_default();
+    assert!(
+        msg.contains("already exists"),
+        "expected 'already exists', got: {msg}"
+    );
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+/// Given: dup_mode is open, dup_input is empty
+/// When: confirm_dup is called
+/// Then: status message contains "cannot be empty", no file created
+#[test]
+fn confirm_dup_empty_name_shows_error() {
+    let tmp = std::env::temp_dir().join(format!("trek_dup_empty_{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&tmp);
+    std::fs::write(tmp.join("script.sh"), b"").unwrap();
+    let mut app = make_app_at(&tmp);
+    app.begin_dup();
+    app.dup_input.clear();
+    app.confirm_dup();
+    let msg = app.status_message.unwrap_or_default();
+    assert!(msg.to_lowercase().contains("cannot be empty"), "got: {msg}");
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+/// Given: a file "archive.tar.gz" (compound extension)
+/// When: begin_dup is called
+/// Then: dup_input is "archive_copy.tar.gz"
+#[test]
+fn begin_dup_compound_extension_suggestion() {
+    let tmp = std::env::temp_dir().join(format!("trek_dup_compound_{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&tmp);
+    std::fs::write(tmp.join("archive.tar.gz"), b"").unwrap();
+    let mut app = make_app_at(&tmp);
+    app.begin_dup();
+    assert_eq!(app.dup_input, "archive_copy.tar.gz");
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+/// Given: a file "Makefile" (no extension)
+/// When: begin_dup is called
+/// Then: dup_input is "Makefile_copy"
+#[test]
+fn begin_dup_no_extension_suggestion() {
+    let tmp = std::env::temp_dir().join(format!("trek_dup_noext_{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&tmp);
+    std::fs::write(tmp.join("Makefile"), b"").unwrap();
+    let mut app = make_app_at(&tmp);
+    app.begin_dup();
+    assert_eq!(app.dup_input, "Makefile_copy");
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+/// Given: begin_dup is called with no entries (empty dir)
+/// When: begin_dup is called
+/// Then: dup_mode remains false (nothing to duplicate)
+#[test]
+fn begin_dup_empty_dir_is_noop() {
+    let tmp = std::env::temp_dir().join(format!("trek_dup_noop_{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&tmp);
+    let mut app = make_app_at(&tmp);
+    app.begin_dup();
+    assert!(!app.dup_mode, "no entries — dup_mode should stay false");
+    let _ = std::fs::remove_dir_all(&tmp);
+}

--- a/src/args.rs
+++ b/src/args.rs
@@ -90,6 +90,7 @@ pub fn print_help() {
     println!("    x           Cut current to clipboard");
     println!("    p           Paste clipboard       Delete      Delete current file/dir");
     println!("    t           New empty file         M           Make new directory");
+    println!("    W           Duplicate selected entry in place (editable name bar)");
     println!("    X           Delete all selected");
     println!("    :           Open command palette");
     println!("    ?           Show help overlay  q           Quit");

--- a/src/events.rs
+++ b/src/events.rs
@@ -67,6 +67,14 @@ pub fn run(
                         KeyCode::Char(c) => app.touch_push_char(c),
                         _ => {}
                     }
+                } else if app.dup_mode {
+                    match key.code {
+                        KeyCode::Esc => app.cancel_dup(),
+                        KeyCode::Enter => app.confirm_dup(),
+                        KeyCode::Backspace => app.dup_pop_char(),
+                        KeyCode::Char(c) => app.dup_push_char(c),
+                        _ => {}
+                    }
                 } else if app.content_search_mode {
                     match key.code {
                         KeyCode::Esc => app.cancel_content_search(),
@@ -236,6 +244,7 @@ pub fn run(
                         KeyCode::Char('X') => app.begin_delete_selected(),
                         KeyCode::Char('M') => app.begin_mkdir(),
                         KeyCode::Char('t') => app.begin_touch(),
+                        KeyCode::Char('W') => app.begin_dup(),
                         // Quick single-file rename
                         KeyCode::Char('n') | KeyCode::F(2) => app.begin_quick_rename(),
                         KeyCode::Char('u') => app.undo_trash(),
@@ -411,6 +420,7 @@ fn execute_palette_action(
         ActionId::ScrollPreviewDown => app.scroll_preview_down(5),
         ActionId::PathJump => app.begin_path_jump(),
         ActionId::GlobSelect => app.begin_glob_select(),
+        ActionId::BeginDup => app.begin_dup(),
         ActionId::ShowHelp => app.show_help = true,
         // Quit appears in the palette for discoverability but cannot break out
         // of the event loop from here — use q directly.

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -103,6 +103,8 @@ pub fn draw(f: &mut Frame, app: &mut App) {
         draw_path_jump_bar(f, app, bottom_area);
     } else if app.glob_mode {
         draw_glob_select_bar(f, app, bottom_area);
+    } else if app.dup_mode {
+        draw_dup_bar(f, app, bottom_area);
     } else if app.mkdir_mode {
         draw_mkdir_bar(f, app, bottom_area);
     } else if app.touch_mode {
@@ -453,6 +455,29 @@ fn draw_touch_bar(f: &mut Frame, app: &App, area: Rect) {
         Span::styled("\u{2588}", Style::default().fg(Color::White)),
         Span::styled(
             "  Enter: create   Esc: cancel",
+            Style::default().fg(Color::DarkGray),
+        ),
+    ]));
+    f.render_widget(para, area);
+}
+
+fn draw_dup_bar(f: &mut Frame, app: &App, area: Rect) {
+    let para = Paragraph::new(Line::from(vec![
+        Span::styled(
+            "Duplicate: ",
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(
+            &app.dup_input,
+            Style::default()
+                .fg(Color::White)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled("\u{2588}", Style::default().fg(Color::White)),
+        Span::styled(
+            "  Enter: copy   Esc: cancel",
             Style::default().fg(Color::DarkGray),
         ),
     ]));
@@ -1530,7 +1555,7 @@ fn draw_palette_overlay(f: &mut Frame, app: &App, size: Rect) {
 
 fn draw_help_overlay(f: &mut Frame, size: Rect) {
     let width = 60u16.min(size.width.saturating_sub(4));
-    let height = 64u16.min(size.height.saturating_sub(4));
+    let height = 66u16.min(size.height.saturating_sub(4));
     let x = (size.width.saturating_sub(width)) / 2;
     let y = (size.height.saturating_sub(height)) / 2;
     let area = Rect::new(x, y, width, height);
@@ -1593,6 +1618,7 @@ fn draw_help_overlay(f: &mut Frame, size: Rect) {
         key_line("Delete / X", "Trash current / selected (recoverable)"),
         key_line("u", "Undo last trash operation"),
         key_line("t", "New file (touch — create empty file)"),
+        key_line("W", "Duplicate selected entry in place"),
         key_line("M", "Make new directory"),
         Line::from(""),
         // ── Yank & Misc ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Adds `W` keybinding that opens a `Duplicate:` bar (Cyan label) pre-filled with a suggested name for the selected entry
- Press Enter to copy the entry to `cwd/<name>`; listing refreshes and cursor selects the new copy
- Directories are duplicated recursively via the existing `ops::copy_path`

## Name suggestion

Uses **first-dot split** to preserve compound extensions:
- `archive.tar.gz` → `archive_copy.tar.gz`
- `config.toml` → `config_copy.toml`
- `Makefile` → `Makefile_copy`

## Error handling

- Destination already exists → `'<name>' already exists` (no overwrite)
- Empty name → `Name cannot be empty`
- Empty directory → noop (bar doesn't open)

## Test plan

- [ ] `cargo test` — 167 tests pass
- [ ] `cargo clippy -- -D warnings` — clean
- [ ] `cargo build --release` — succeeds
- [ ] Press `W` on a file → bar opens with `<stem>_copy.<ext>`
- [ ] Press `W` on `archive.tar.gz` → bar shows `archive_copy.tar.gz`
- [ ] Press `W` on `Makefile` → bar shows `Makefile_copy`
- [ ] Edit name, Enter → copy created, cursor on new entry
- [ ] Type existing name, Enter → error shown, no overwrite
- [ ] Esc → bar closes, no filesystem change
- [ ] Press `W` on a directory → recursive copy with `_copy` suffix

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)