### PR TITLE
feat(yank): add yank path format picker (A)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.28.0] - 2026-03-24
+
+### Added
+- **`A` — yank path format picker**: press `A` on any entry to open a compact four-option overlay just above the status bar; press a single mnemonic key to copy in the desired format via OSC 52 and close the picker
+- Four formats: `r` (relative `./…`), `a` (absolute `/…`), `f` (filename only), `p` (parent directory path); numeric aliases `1`–`4` also accepted
+- `strip_prefix` failure (e.g. symlink outside cwd) causes `r` to fall back to absolute path without panic; `parent()` returning `None` (root `/`) copies `/` without panic
+- Paths longer than 44 characters are truncated with `…` in the overlay display; the **full untruncated string** is what gets copied to the clipboard
+- Existing `y` (relative) and `Y` (absolute) direct bindings are unchanged
+- `A` on an empty directory is a no-op (picker does not open)
+- `Esc` dismisses the picker without copying or setting a status message; any unrecognised key is silently ignored while the picker stays open
+- `A` registered in the command palette as "Yank path (pick format: relative/absolute/filename/parent)"
+- `A` documented in help overlay (`?`) under Yank & Misc and in `--help` output
+- New methods: `yank_filename`, `yank_parent_dir`, `open_yank_picker`, `close_yank_picker` in `src/app/yank.rs`
+- 6 new BDD-style unit tests; all 173 tests pass
+
 ## [0.27.0] - 2026-03-24
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -586,7 +586,7 @@ dependencies = [
 
 [[package]]
 name = "trek"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trek"
-version = "0.27.0"
+version = "0.28.0"
 edition = "2021"
 rust-version = "1.80"
 description = "A terminal file manager with mouse-resizable panes"

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -303,6 +303,10 @@ pub struct App {
     /// Glob pattern typed by the user.
     pub glob_input: String,
 
+    // --- Yank picker (A) ---
+    /// True while the yank format picker overlay is open.
+    pub yank_picker_mode: bool,
+
     // --- File duplication (W) ---
     /// True while the duplicate name input bar is open.
     pub dup_mode: bool,
@@ -416,6 +420,7 @@ impl App {
             show_line_numbers: false,
             glob_mode: false,
             glob_input: String::new(),
+            yank_picker_mode: false,
             dup_mode: false,
             dup_input: String::new(),
             dup_src: None,

--- a/src/app/palette.rs
+++ b/src/app/palette.rs
@@ -43,6 +43,7 @@ pub enum ActionId {
     ToggleSortOrder,
     YankRelativePath,
     YankAbsolutePath,
+    OpenYankPicker,
     ToggleLineNumbers,
     ScrollPreviewUp,
     ScrollPreviewDown,
@@ -247,6 +248,11 @@ pub static PALETTE_ACTIONS: &[PaletteAction] = &[
         id: ActionId::YankAbsolutePath,
         name: "Yank absolute path to clipboard",
         keys: "Y",
+    },
+    PaletteAction {
+        id: ActionId::OpenYankPicker,
+        name: "Yank path (pick format: relative/absolute/filename/parent)",
+        keys: "A",
     },
     PaletteAction {
         id: ActionId::ToggleLineNumbers,

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -1914,3 +1914,96 @@ fn begin_dup_empty_dir_is_noop() {
     assert!(!app.dup_mode, "no entries — dup_mode should stay false");
     let _ = std::fs::remove_dir_all(&tmp);
 }
+
+// ── Yank path format picker (A) ─────────────────────────────────────────────
+
+/// Given: a directory with at least one entry
+/// When: open_yank_picker is called
+/// Then: yank_picker_mode is true
+#[test]
+fn open_yank_picker_sets_mode() {
+    let tmp = std::env::temp_dir().join(format!("trek_yp_open_{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&tmp);
+    std::fs::write(tmp.join("main.rs"), b"").unwrap();
+    let mut app = make_app_at(&tmp);
+    app.open_yank_picker();
+    assert!(app.yank_picker_mode);
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+/// Given: an empty directory
+/// When: open_yank_picker is called
+/// Then: yank_picker_mode stays false (nothing to yank)
+#[test]
+fn open_yank_picker_empty_dir_is_noop() {
+    let tmp = std::env::temp_dir().join(format!("trek_yp_empty_{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&tmp);
+    let mut app = make_app_at(&tmp);
+    app.open_yank_picker();
+    assert!(!app.yank_picker_mode);
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+/// Given: yank_picker_mode is true
+/// When: close_yank_picker is called
+/// Then: yank_picker_mode is false
+#[test]
+fn close_yank_picker_clears_mode() {
+    let tmp = std::env::temp_dir().join(format!("trek_yp_close_{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&tmp);
+    std::fs::write(tmp.join("lib.rs"), b"").unwrap();
+    let mut app = make_app_at(&tmp);
+    app.open_yank_picker();
+    assert!(app.yank_picker_mode);
+    app.close_yank_picker();
+    assert!(!app.yank_picker_mode);
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+/// Given: a file "config.toml" in a temp dir
+/// When: yank_filename is called
+/// Then: status_message contains "[yank] config.toml"
+#[test]
+fn yank_filename_sets_status_message() {
+    let tmp = std::env::temp_dir().join(format!("trek_yp_fname_{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&tmp);
+    std::fs::write(tmp.join("config.toml"), b"").unwrap();
+    let mut app = make_app_at(&tmp);
+    app.yank_filename();
+    let msg = app.status_message.unwrap_or_default();
+    assert!(
+        msg.contains("[yank]") && msg.contains("config.toml"),
+        "got: {msg}"
+    );
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+/// Given: a file "src/main.rs" (relative to cwd)
+/// When: yank_parent_dir is called
+/// Then: status_message contains "[yank]" and the parent path
+#[test]
+fn yank_parent_dir_sets_status_message() {
+    let tmp = std::env::temp_dir().join(format!("trek_yp_parent_{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&tmp);
+    std::fs::write(tmp.join("notes.md"), b"").unwrap();
+    let mut app = make_app_at(&tmp);
+    app.yank_parent_dir();
+    let msg = app.status_message.unwrap_or_default();
+    assert!(msg.contains("[yank]"), "status should show [yank]: {msg}");
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+/// Given: yank_filename called on an entry with no extension
+/// When: yank_filename is called
+/// Then: status_message contains the bare filename
+#[test]
+fn yank_filename_no_extension() {
+    let tmp = std::env::temp_dir().join(format!("trek_yp_noext_{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&tmp);
+    std::fs::write(tmp.join("Makefile"), b"").unwrap();
+    let mut app = make_app_at(&tmp);
+    app.yank_filename();
+    let msg = app.status_message.unwrap_or_default();
+    assert!(msg.contains("Makefile"), "got: {msg}");
+    let _ = std::fs::remove_dir_all(&tmp);
+}

--- a/src/app/yank.rs
+++ b/src/app/yank.rs
@@ -19,6 +19,46 @@ impl App {
         }
     }
 
+    /// Copy just the filename (not the full path) to the clipboard.
+    pub fn yank_filename(&mut self) {
+        if let Some(entry) = self.entries.get(self.selected) {
+            let name = entry
+                .path
+                .file_name()
+                .map(|n| n.to_string_lossy().into_owned())
+                .unwrap_or_else(|| entry.name.clone());
+            self.osc52_copy(&name);
+            self.status_message = Some(format!("[yank] {}", name));
+        }
+    }
+
+    /// Copy the parent directory of the selected entry to the clipboard.
+    pub fn yank_parent_dir(&mut self) {
+        if let Some(entry) = self.entries.get(self.selected) {
+            let parent = entry
+                .path
+                .parent()
+                .map(|p| p.to_string_lossy().into_owned())
+                .unwrap_or_else(|| "/".to_string());
+            self.osc52_copy(&parent);
+            self.status_message = Some(format!("[yank] {}", parent));
+        }
+    }
+
+    /// Open the yank format picker overlay.
+    ///
+    /// Does nothing when the directory is empty (no entry to yank).
+    pub fn open_yank_picker(&mut self) {
+        if self.entries.get(self.selected).is_some() {
+            self.yank_picker_mode = true;
+        }
+    }
+
+    /// Close the yank format picker without copying anything.
+    pub fn close_yank_picker(&mut self) {
+        self.yank_picker_mode = false;
+    }
+
     /// Write an OSC 52 sequence to set the system clipboard.
     fn osc52_copy(&self, text: &str) {
         use base64::Engine;

--- a/src/args.rs
+++ b/src/args.rs
@@ -77,6 +77,9 @@ pub fn print_help() {
     println!("    [           Scroll preview up 5 lines  ]  Scroll preview down 5 lines");
     println!("    /           Fuzzy search       Ctrl+F      Content search (rg)");
     println!("    y / Y       Yank relative / absolute path");
+    println!(
+        "    A           Yank path (pick format: r=relative  a=absolute  f=filename  p=parent dir)"
+    );
     println!("    #           Toggle line numbers in preview pane");
     println!("    i           Toggle gitignore filter (hide .gitignored files)");
     println!("    d           Toggle diff preview R           Refresh git status");

--- a/src/events.rs
+++ b/src/events.rs
@@ -179,6 +179,27 @@ pub fn run(
                         KeyCode::Char(c) => app.palette_push_char(c),
                         _ => {}
                     }
+                } else if app.yank_picker_mode {
+                    match key.code {
+                        KeyCode::Esc => app.close_yank_picker(),
+                        KeyCode::Char('r') | KeyCode::Char('1') => {
+                            app.close_yank_picker();
+                            app.yank_relative_path();
+                        }
+                        KeyCode::Char('a') | KeyCode::Char('2') => {
+                            app.close_yank_picker();
+                            app.yank_absolute_path();
+                        }
+                        KeyCode::Char('f') | KeyCode::Char('3') => {
+                            app.close_yank_picker();
+                            app.yank_filename();
+                        }
+                        KeyCode::Char('p') | KeyCode::Char('4') => {
+                            app.close_yank_picker();
+                            app.yank_parent_dir();
+                        }
+                        _ => {}
+                    }
                 } else if app.search_mode {
                     match key.code {
                         KeyCode::Esc => app.cancel_search(),
@@ -217,6 +238,7 @@ pub fn run(
                         KeyCode::Char('|') => app.start_filter(),
                         KeyCode::Char('y') => app.yank_relative_path(),
                         KeyCode::Char('Y') => app.yank_absolute_path(),
+                        KeyCode::Char('A') => app.open_yank_picker(),
                         KeyCode::Char('d') => app.toggle_diff_preview(),
                         KeyCode::Char('m') => app.toggle_meta_preview(),
                         KeyCode::Char('P') => app.begin_chmod(),
@@ -415,6 +437,7 @@ fn execute_palette_action(
         ActionId::ToggleSortOrder => app.toggle_sort_order(),
         ActionId::YankRelativePath => app.yank_relative_path(),
         ActionId::YankAbsolutePath => app.yank_absolute_path(),
+        ActionId::OpenYankPicker => app.open_yank_picker(),
         ActionId::ToggleLineNumbers => app.toggle_line_numbers(),
         ActionId::ScrollPreviewUp => app.scroll_preview_up(5),
         ActionId::ScrollPreviewDown => app.scroll_preview_down(5),

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -183,6 +183,11 @@ pub fn draw(f: &mut Frame, app: &mut App) {
         draw_bookmark_overlay(f, app, size);
     }
 
+    // Yank picker overlay.
+    if app.yank_picker_mode {
+        draw_yank_picker(f, app, size);
+    }
+
     // Command palette overlay (rendered on top of everything else).
     if app.palette_mode {
         draw_palette_overlay(f, app, size);
@@ -1553,9 +1558,81 @@ fn draw_palette_overlay(f: &mut Frame, app: &App, size: Rect) {
     f.render_widget(hint, hint_area);
 }
 
+fn draw_yank_picker(f: &mut Frame, app: &App, size: Rect) {
+    let Some(entry) = app.entries.get(app.selected) else {
+        return;
+    };
+
+    let rel = {
+        let r = entry.path.strip_prefix(&app.cwd).unwrap_or(&entry.path);
+        format!("./{}", r.display())
+    };
+    let abs = entry.path.to_string_lossy().into_owned();
+    let fname = entry
+        .path
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_else(|| entry.name.clone());
+    let parent = entry
+        .path
+        .parent()
+        .map(|p| p.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "/".to_string());
+
+    let truncate = |s: String| -> String {
+        if s.chars().count() > 44 {
+            format!("{}…", s.chars().take(43).collect::<String>())
+        } else {
+            s
+        }
+    };
+
+    let key_style = Style::default()
+        .fg(Color::Yellow)
+        .add_modifier(Modifier::BOLD);
+    let rows = vec![
+        Line::from(vec![
+            Span::styled(" r ", key_style),
+            Span::raw(format!(" {}", truncate(rel))),
+        ]),
+        Line::from(vec![
+            Span::styled(" a ", key_style),
+            Span::raw(format!(" {}", truncate(abs))),
+        ]),
+        Line::from(vec![
+            Span::styled(" f ", key_style),
+            Span::raw(format!(" {}", truncate(fname))),
+        ]),
+        Line::from(vec![
+            Span::styled(" p ", key_style),
+            Span::raw(format!(" {}", truncate(parent))),
+        ]),
+    ];
+
+    let width = 52u16.min(size.width);
+    let height = 6u16; // border top + 4 rows + border bottom
+    let x = 0;
+    let y = size.height.saturating_sub(height + 1); // +1 for status bar row
+
+    let area = Rect {
+        x,
+        y,
+        width,
+        height,
+    };
+    f.render_widget(Clear, area);
+    let block = Block::default()
+        .title(" Yank path ")
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Yellow));
+    let inner = block.inner(area);
+    f.render_widget(block, area);
+    f.render_widget(Paragraph::new(rows), inner);
+}
+
 fn draw_help_overlay(f: &mut Frame, size: Rect) {
     let width = 60u16.min(size.width.saturating_sub(4));
-    let height = 66u16.min(size.height.saturating_sub(4));
+    let height = 68u16.min(size.height.saturating_sub(4));
     let x = (size.width.saturating_sub(width)) / 2;
     let y = (size.height.saturating_sub(height)) / 2;
     let area = Rect::new(x, y, width, height);
@@ -1624,6 +1701,10 @@ fn draw_help_overlay(f: &mut Frame, size: Rect) {
         // ── Yank & Misc ─────────────────────────────────────────────────────
         section_header("Yank & Misc"),
         key_line("y / Y", "Yank relative / absolute path"),
+        key_line(
+            "A",
+            "Yank path (pick format: r=relative a=absolute f=filename p=parent)",
+        ),
         key_line(":", "Open command palette"),
         key_line("Q", "Quit"),
         key_line("?", "Toggle this help"),


### PR DESCRIPTION
## Summary

- Adds `A` keybinding that opens a compact overlay showing all four path formats for the selected entry
- Press a single mnemonic key to copy and close: `r` (relative), `a` (absolute), `f` (filename only), `p` (parent directory)
- Numeric aliases `1`–`4` also accepted; `Esc` dismisses without copying; any other key is silently ignored
- Directly serves Trek's routing mission — filename-only and parent-dir formats were previously inaccessible without leaving Trek

## Overlay

```
┌─ Yank path ────────────────────────────────────┐
│  r  ./src/app/mod.rs                            │
│  a  /Users/alice/project/src/app/mod.rs         │
│  f  mod.rs                                      │
│  p  /Users/alice/project/src/app                │
└─────────────────────────────────────────────────┘
```

## Test plan

- [ ] `cargo test` — 173 tests pass
- [ ] `cargo clippy -- -D warnings` — clean
- [ ] `cargo build --release` — succeeds
- [ ] Press `A` on a file → picker overlay opens with 4 path formats
- [ ] Press `r` → relative path copied, status shows `[yank] ./...`
- [ ] Press `a` → absolute path copied
- [ ] Press `f` → filename only copied, status shows `[yank] filename.ext`
- [ ] Press `p` → parent dir copied
- [ ] Press `1`–`4` → same as r/a/f/p respectively
- [ ] Press `Esc` → picker closes, no status message
- [ ] Any other key → picker stays open
- [ ] `A` on empty directory → noop (picker doesn't open)
- [ ] Existing `y` and `Y` bindings still work unchanged

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)