### PR TITLE
feat(trek): clipboard inspector overlay (F key) — v0.36.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.36.0] - 2026-03-24
+
+### Added
+- **`F` — clipboard inspector**: press `F` to open an overlay showing the current clipboard contents (paths queued for copy or cut)
+- Overlay title and border are green for copy operations, yellow for cut operations, and grey when clipboard is empty
+- Press `p` inside the inspector to close and immediately paste; press `Esc` or `F` to close without action
+- `InspectClipboard` registered in the command palette as "Inspect clipboard contents" and in the `?` help overlay
+
 ## [0.35.0] - 2026-03-24
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trek"
-version = "0.35.0"
+version = "0.36.0"
 edition = "2021"
 rust-version = "1.80"
 description = "A terminal file manager with mouse-resizable panes"

--- a/src/app/file_ops.rs
+++ b/src/app/file_ops.rs
@@ -491,4 +491,14 @@ impl App {
     pub fn symlink_pop_char(&mut self) {
         self.symlink_input.pop();
     }
+
+    /// Open the clipboard inspector overlay.
+    pub fn open_clipboard_inspect(&mut self) {
+        self.clipboard_inspect_mode = true;
+    }
+
+    /// Close the clipboard inspector overlay without taking any action.
+    pub fn close_clipboard_inspect(&mut self) {
+        self.clipboard_inspect_mode = false;
+    }
 }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -320,6 +320,10 @@ pub struct App {
     /// When true, the listing shows last-modified dates instead of file sizes.
     pub show_timestamps: bool,
 
+    // --- Clipboard inspector (F) ---
+    /// True while the clipboard contents overlay is open.
+    pub clipboard_inspect_mode: bool,
+
     // --- Glob pattern selection (*) ---
     /// True while the glob pattern input bar is open.
     pub glob_mode: bool,
@@ -478,6 +482,7 @@ impl App {
             dup_mode: false,
             dup_input: String::new(),
             dup_src: None,
+            clipboard_inspect_mode: false,
         };
         app.load_dir();
         Ok(app)

--- a/src/app/palette.rs
+++ b/src/app/palette.rs
@@ -58,6 +58,7 @@ pub enum ActionId {
     GlobSelect,
     BeginDup,
     BeginSymlink,
+    InspectClipboard,
     ShowHelp,
     Quit,
 }
@@ -331,6 +332,11 @@ pub static PALETTE_ACTIONS: &[PaletteAction] = &[
         id: ActionId::BeginSymlink,
         name: "Create symlink to selected entry",
         keys: "L",
+    },
+    PaletteAction {
+        id: ActionId::InspectClipboard,
+        name: "Inspect clipboard contents",
+        keys: "F",
     },
     PaletteAction {
         id: ActionId::ShowHelp,

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -2733,3 +2733,50 @@ fn read_entries_populates_child_count_for_dir() {
     );
     let _ = std::fs::remove_dir_all(&parent);
 }
+
+// ── Clipboard inspector tests (issue #70) ────────────────────────────────────
+
+/// Given: clipboard_inspect_mode is false
+/// When: open_clipboard_inspect is called
+/// Then: clipboard_inspect_mode becomes true
+#[test]
+fn open_clipboard_inspect_enters_mode() {
+    let tmp = std::env::temp_dir().join(format!("trek_ci_open_{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&tmp);
+    std::fs::write(tmp.join("f.txt"), b"hi").unwrap();
+    let mut app = make_app_at(&tmp);
+    assert!(!app.clipboard_inspect_mode);
+    app.open_clipboard_inspect();
+    assert!(app.clipboard_inspect_mode);
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+/// Given: clipboard_inspect_mode is true
+/// When: close_clipboard_inspect is called
+/// Then: clipboard_inspect_mode becomes false
+#[test]
+fn close_clipboard_inspect_exits_mode() {
+    let tmp = std::env::temp_dir().join(format!("trek_ci_close_{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&tmp);
+    std::fs::write(tmp.join("f.txt"), b"hi").unwrap();
+    let mut app = make_app_at(&tmp);
+    app.open_clipboard_inspect();
+    app.close_clipboard_inspect();
+    assert!(!app.clipboard_inspect_mode);
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+/// Given: clipboard is None (empty)
+/// When: open_clipboard_inspect is called
+/// Then: overlay opens without panicking
+#[test]
+fn open_clipboard_inspect_with_empty_clipboard() {
+    let tmp = std::env::temp_dir().join(format!("trek_ci_empty_{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&tmp);
+    std::fs::write(tmp.join("f.txt"), b"hi").unwrap();
+    let mut app = make_app_at(&tmp);
+    assert!(app.clipboard.is_none());
+    app.open_clipboard_inspect(); // must not panic
+    assert!(app.clipboard_inspect_mode);
+    let _ = std::fs::remove_dir_all(&tmp);
+}

--- a/src/args.rs
+++ b/src/args.rs
@@ -97,7 +97,7 @@ pub fn print_help() {
     println!("    r           Bulk rename selected files with regex  Esc  Clear selections");
     println!("    o           Open in $EDITOR        O           Open with system default");
     println!("    c           Copy current to clipboard C          Copy selected to clipboard");
-    println!("    x           Cut current to clipboard");
+    println!("    x           Cut current to clipboard  F           Inspect clipboard contents");
     println!("    p           Paste clipboard       Delete      Delete current file/dir");
     println!("    t           New empty file         M           Make new directory");
     println!("    L           Create symlink to selected entry (Unix only)");

--- a/src/events.rs
+++ b/src/events.rs
@@ -208,6 +208,17 @@ pub fn run(
                         }
                         _ => {}
                     }
+                } else if app.clipboard_inspect_mode {
+                    match key.code {
+                        KeyCode::Esc | KeyCode::Char('F') | KeyCode::Char('q') => {
+                            app.close_clipboard_inspect()
+                        }
+                        KeyCode::Char('p') => {
+                            app.close_clipboard_inspect();
+                            app.paste_clipboard();
+                        }
+                        _ => {}
+                    }
                 } else if app.mark_set_mode {
                     match key.code {
                         KeyCode::Char(c) if c.is_alphabetic() => app.set_mark(c),
@@ -264,6 +275,7 @@ pub fn run(
                         KeyCode::Char('T') => app.toggle_timestamps(),
                         KeyCode::Char('U') => app.toggle_preview_wrap(),
                         KeyCode::Char('N') => app.toggle_dir_counts(),
+                        KeyCode::Char('F') => app.open_clipboard_inspect(),
                         KeyCode::Char('P') => app.begin_chmod(),
                         KeyCode::Char('R') => app.refresh_git_status(),
                         KeyCode::Char('?') => app.show_help = true,
@@ -479,6 +491,7 @@ fn execute_palette_action(
         ActionId::GlobSelect => app.begin_glob_select(),
         ActionId::BeginDup => app.begin_dup(),
         ActionId::BeginSymlink => app.begin_symlink(),
+        ActionId::InspectClipboard => app.open_clipboard_inspect(),
         ActionId::ShowHelp => app.show_help = true,
         // Quit appears in the palette for discoverability but cannot break out
         // of the event loop from here — use q directly.

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -192,6 +192,11 @@ pub fn draw(f: &mut Frame, app: &mut App) {
         draw_yank_picker(f, app, size);
     }
 
+    // Clipboard inspector overlay.
+    if app.clipboard_inspect_mode {
+        draw_clipboard_inspect_overlay(f, app, size);
+    }
+
     // Command palette overlay (rendered on top of everything else).
     if app.palette_mode {
         draw_palette_overlay(f, app, size);
@@ -1618,6 +1623,87 @@ fn draw_palette_overlay(f: &mut Frame, app: &App, size: Rect) {
     f.render_widget(hint, hint_area);
 }
 
+fn draw_clipboard_inspect_overlay(f: &mut Frame, app: &App, size: Rect) {
+    let (op_label, border_color) = match app.clipboard.as_ref().map(|c| c.op) {
+        Some(ClipboardOp::Copy) => (" Clipboard — copy ", Color::Green),
+        Some(ClipboardOp::Cut) => (" Clipboard — cut ", Color::Yellow),
+        None => (" Clipboard — empty ", Color::DarkGray),
+    };
+
+    let truncate = |s: String| -> String {
+        let max = 52usize;
+        if s.chars().count() > max {
+            format!("{}…", s.chars().take(max - 1).collect::<String>())
+        } else {
+            s
+        }
+    };
+
+    let rows: Vec<Line> = if let Some(clip) = &app.clipboard {
+        clip.paths
+            .iter()
+            .map(|p| {
+                let name = p
+                    .file_name()
+                    .map(|n| n.to_string_lossy().into_owned())
+                    .unwrap_or_else(|| p.to_string_lossy().into_owned());
+                Line::from(truncate(name))
+            })
+            .collect()
+    } else {
+        vec![Line::from(Span::styled(
+            " (nothing in clipboard)",
+            Style::default().fg(Color::DarkGray),
+        ))]
+    };
+
+    let hint = Line::from(vec![
+        Span::styled(
+            " p",
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::raw(" paste  "),
+        Span::styled(
+            "Esc",
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::raw(" close"),
+    ]);
+
+    let content_height = rows.len() as u16 + 1; // items + hint
+    let height = (content_height + 2).min(size.height.saturating_sub(2)); // +2 border
+    let width = 58u16.min(size.width);
+    let x = 0;
+    let y = size.height.saturating_sub(height + 1); // +1 for status bar
+
+    let area = Rect {
+        x,
+        y,
+        width,
+        height,
+    };
+    f.render_widget(Clear, area);
+    let block = Block::default()
+        .title(op_label)
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(border_color));
+    let inner = block.inner(area);
+    f.render_widget(block, area);
+
+    // Split inner area: items on top, hint on bottom
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Min(1), Constraint::Length(1)])
+        .split(inner);
+
+    f.render_widget(Paragraph::new(rows), chunks[0]);
+    f.render_widget(Paragraph::new(hint), chunks[1]);
+}
+
 fn draw_yank_picker(f: &mut Frame, app: &App, size: Rect) {
     let Some(entry) = app.entries.get(app.selected) else {
         return;
@@ -1692,7 +1778,7 @@ fn draw_yank_picker(f: &mut Frame, app: &App, size: Rect) {
 
 fn draw_help_overlay(f: &mut Frame, size: Rect) {
     let width = 60u16.min(size.width.saturating_sub(4));
-    let height = 82u16.min(size.height.saturating_sub(4));
+    let height = 84u16.min(size.height.saturating_sub(4));
     let x = (size.width.saturating_sub(width)) / 2;
     let y = (size.height.saturating_sub(height)) / 2;
     let area = Rect::new(x, y, width, height);
@@ -1764,6 +1850,7 @@ fn draw_help_overlay(f: &mut Frame, size: Rect) {
         key_line("O", "Open with system default (background)"),
         key_line("c / C", "Copy current / selected"),
         key_line("x", "Cut current to clipboard"),
+        key_line("F", "Inspect clipboard contents"),
         key_line("p", "Paste clipboard into current dir"),
         key_line("Delete / X", "Trash current / selected (recoverable)"),
         key_line("u", "Undo last trash operation"),


### PR DESCRIPTION
## Summary
- Adds `F` key to open a clipboard inspector overlay showing all files queued for copy or cut
- Overlay border is green for copy, yellow for cut, grey when clipboard is empty
- Press `p` inside inspector to paste immediately; `Esc`/`F` to dismiss without action
- `InspectClipboard` registered in command palette and help overlay

## Test plan
- [ ] `cargo test` — all 215 tests pass
- [ ] `cargo clippy -- -D warnings` — no warnings
- [ ] `cargo build --release` — builds clean at v0.36.0
- [ ] Manual: copy a file (`c`), press `F` — green overlay shows filename
- [ ] Manual: cut a file (`x`), press `F` — yellow overlay shows filename
- [ ] Manual: press `p` inside inspector — pastes and closes
- [ ] Manual: press `Esc` inside inspector — closes without pasting
- [ ] Manual: with empty clipboard, press `F` — grey overlay with "(nothing in clipboard)"
- [ ] Manual: `F` visible in `?` help overlay under File Operations
- [ ] Manual: "Inspect clipboard contents" discoverable in command palette (`:`)

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)