### PR TITLE
feat(trek): selection total size in status bar — v0.37.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.37.0] - 2026-03-24
+
+### Added
+- **Selection total size in status bar**: when one or more files are selected, the bottom bar now shows the aggregate byte size alongside the count — e.g., `" 3 selected  (2.4 MB)"`
+- Directories in the selection do not contribute to the total (their `DirEntry.size` is a meaningless filesystem block size)
+- When only directories are selected the size annotation is omitted entirely
+- `C` (copy-selected) status message now also includes total file size: `"[copy] 3 files (2.4 MB)"`
+
 ## [0.36.0] - 2026-03-24
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trek"
-version = "0.36.0"
+version = "0.37.0"
 edition = "2021"
 rust-version = "1.80"
 description = "A terminal file manager with mouse-resizable panes"

--- a/src/app/file_ops.rs
+++ b/src/app/file_ops.rs
@@ -39,12 +39,25 @@ impl App {
             return;
         }
         let count = paths.len();
+        // Compute total size of selected files before clearing rename_selected.
+        let total_bytes: u64 = self
+            .rename_selected
+            .iter()
+            .filter_map(|&i| self.entries.get(i))
+            .filter(|e| !e.is_dir)
+            .map(|e| e.size)
+            .sum();
         self.clipboard = Some(Clipboard {
             op: ClipboardOp::Copy,
             paths,
         });
         self.rename_selected.clear();
-        self.status_message = Some(format!("[copy] {} files", count));
+        let size_str = if total_bytes > 0 {
+            format!(" ({})", crate::app::format_size(total_bytes))
+        } else {
+            String::new()
+        };
+        self.status_message = Some(format!("[copy] {} files{}", count, size_str));
     }
 
     /// Mark the currently selected entry for cut.

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -2780,3 +2780,74 @@ fn open_clipboard_inspect_with_empty_clipboard() {
     assert!(app.clipboard_inspect_mode);
     let _ = std::fs::remove_dir_all(&tmp);
 }
+
+/// Given: rename_selected contains indices pointing to files with known sizes
+/// When: clipboard_copy_selected is called
+/// Then: the status message includes aggregate file size in parentheses
+#[test]
+fn copy_selected_status_includes_total_size() {
+    let tmp = std::env::temp_dir().join(format!("trek_sel_size_{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&tmp);
+    // Write two files with known sizes
+    std::fs::write(tmp.join("a.txt"), &vec![0u8; 1024]).unwrap(); // 1 KB
+    std::fs::write(tmp.join("b.txt"), &vec![0u8; 1024]).unwrap(); // 1 KB
+    let mut app = make_app_at(&tmp);
+    // Select both files
+    app.rename_selected.insert(0);
+    app.rename_selected.insert(1);
+    app.clipboard_copy_selected();
+    let msg = app.status_message.clone().unwrap_or_default();
+    assert!(msg.contains("2 files"), "should show count: {msg}");
+    assert!(
+        msg.contains('(') && msg.contains(')'),
+        "should include size in parens: {msg}"
+    );
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+/// Given: rename_selected contains only a directory index
+/// When: clipboard_copy_selected is called
+/// Then: the status message contains no parenthesised size (dirs excluded)
+#[test]
+fn copy_selected_status_omits_size_for_dirs_only() {
+    let tmp = std::env::temp_dir().join(format!("trek_sel_dir_{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&tmp);
+    let subdir = tmp.join("subdir");
+    std::fs::create_dir_all(&subdir).unwrap();
+    let mut app = make_app_at(&tmp);
+    // Select the directory (index 0 in a single-entry listing)
+    app.rename_selected.insert(0);
+    app.clipboard_copy_selected();
+    let msg = app.status_message.clone().unwrap_or_default();
+    // Message should NOT have a size annotation
+    assert!(
+        !msg.contains('('),
+        "should not show size for dirs-only selection: {msg}"
+    );
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+/// Given: rename_selected contains a mix of files and a directory
+/// When: clipboard_copy_selected is called
+/// Then: only file sizes contribute — message includes parenthesised total
+#[test]
+fn copy_selected_status_sums_only_files_in_mixed_selection() {
+    let tmp = std::env::temp_dir().join(format!("trek_sel_mix_{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&tmp);
+    let subdir = tmp.join("adir"); // sorted before file
+    std::fs::create_dir_all(&subdir).unwrap();
+    std::fs::write(tmp.join("zfile.txt"), &vec![0u8; 512]).unwrap();
+    let mut app = make_app_at(&tmp);
+    // Select both (indices 0 and 1 in a two-entry listing)
+    app.rename_selected.insert(0);
+    app.rename_selected.insert(1);
+    app.clipboard_copy_selected();
+    let msg = app.status_message.clone().unwrap_or_default();
+    assert!(msg.contains("2 files"), "should show total count: {msg}");
+    // Should include size from the file (not the dir)
+    assert!(
+        msg.contains('(') && msg.contains(')'),
+        "should include file size: {msg}"
+    );
+    let _ = std::fs::remove_dir_all(&tmp);
+}

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -133,9 +133,21 @@ pub fn draw(f: &mut Frame, app: &mut App) {
         f.render_widget(para, bottom_area);
     } else if !app.rename_selected.is_empty() {
         let count = app.rename_selected.len();
+        let total_bytes: u64 = app
+            .rename_selected
+            .iter()
+            .filter_map(|&i| app.entries.get(i))
+            .filter(|e| !e.is_dir)
+            .map(|e| e.size)
+            .sum();
+        let size_label = if total_bytes > 0 {
+            format!("  ({})", format_size(total_bytes))
+        } else {
+            String::new()
+        };
         let para = Paragraph::new(Line::from(vec![
             Span::styled(
-                format!(" {} selected", count),
+                format!(" {} selected{}", count, size_label),
                 Style::default()
                     .fg(Color::Magenta)
                     .add_modifier(Modifier::BOLD),


### PR DESCRIPTION
## Summary
- Selection bar now shows aggregate byte size alongside count: `" 3 selected  (2.4 MB)"`
- Directories excluded from total (their DirEntry.size is a meaningless block size)
- `C` (copy-selected) status message also includes total: `"[copy] 3 files (2.4 MB)"`

## Test plan
- [ ] `cargo test` — all 218 tests pass
- [ ] `cargo clippy -- -D warnings` — no warnings
- [ ] `cargo build --release` — builds clean at v0.37.0
- [ ] Manual: select 2+ files with `J`/`Space` — bottom bar shows size in parens
- [ ] Manual: select only directories — no size annotation shown
- [ ] Manual: `C` (copy-selected) — status message includes file size total
- [ ] Manual: single zero-byte file selected — shows `(0 B)` or no annotation (0 → empty string)

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)