### PR TITLE
feat(trek): symlink target and validity in meta preview card — v0.38.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.38.0] - 2026-03-24
+
+### Added
+- **Symlink target and validity in meta preview (`m`)**: the meta card for a symlink now shows two additional lines immediately after `Type`:
+  - `Target` — the raw stored link path (relative targets shown as-is; `$HOME` replaced with `~`)
+  - `Valid  ✓  exists` or `Valid  ✗  dangling` depending on whether the full symlink chain resolves
+- A permission error reading the link shows `Target    (unreadable)` with no `Valid` line
+- Regular file and directory meta cards are unchanged
+
 ## [0.37.0] - 2026-03-24
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trek"
-version = "0.37.0"
+version = "0.38.0"
 edition = "2021"
 rust-version = "1.80"
 description = "A terminal file manager with mouse-resizable panes"

--- a/src/app/metadata.rs
+++ b/src/app/metadata.rs
@@ -147,10 +147,41 @@ impl App {
                     .map(|d| format_unix_timestamp_utc(d.as_secs()))
                     .unwrap_or_else(|| "unavailable".to_string())
             };
-            vec![
+            let mut lines = vec![
                 String::new(),
                 format!("  Path      {}", path.display()),
                 format!("  Type      {}", file_type),
+            ];
+
+            // For symlinks: show stored target path and whether it resolves.
+            if meta.file_type().is_symlink() {
+                match std::fs::read_link(path) {
+                    Ok(target) => {
+                        let home = std::env::var("HOME").unwrap_or_default();
+                        let raw = target.to_string_lossy().into_owned();
+                        let display = if !home.is_empty() {
+                            raw.replace(&home, "~")
+                        } else {
+                            raw
+                        };
+                        lines.push(format!("  Target    {}", display));
+                        let valid = path.exists();
+                        lines.push(format!(
+                            "  Valid     {}",
+                            if valid {
+                                "\u{2713}  exists"
+                            } else {
+                                "\u{2717}  dangling"
+                            }
+                        ));
+                    }
+                    Err(_) => {
+                        lines.push("  Target    (unreadable)".to_string());
+                    }
+                }
+            }
+
+            lines.extend([
                 format!("  Size      {} ({} bytes)", meta_human_size(size), size),
                 format!(
                     "  Mode      {} ({:04o})",
@@ -160,7 +191,9 @@ impl App {
                 format!("  UID / GID {} / {}", meta.uid(), meta.gid()),
                 format!("  Modified  {}", fmt_time(meta.modified())),
                 format!("  Accessed  {}", fmt_time(meta.accessed())),
-            ]
+            ]);
+
+            lines
         }
         #[cfg(not(unix))]
         {

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -2851,3 +2851,74 @@ fn copy_selected_status_sums_only_files_in_mixed_selection() {
     );
     let _ = std::fs::remove_dir_all(&tmp);
 }
+
+/// Given: a symlink pointing to an existing target
+/// When: load_meta_lines is called on the symlink path
+/// Then: the output contains a "Target" line and a "Valid" line showing "exists"
+#[test]
+#[cfg(unix)]
+fn meta_lines_symlink_valid_shows_target_and_exists() {
+    let tmp = std::env::temp_dir().join(format!("trek_sl_valid_{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&tmp);
+    let target = tmp.join("real.txt");
+    std::fs::write(&target, b"hello").unwrap();
+    let link = tmp.join("link.txt");
+    std::os::unix::fs::symlink(&target, &link).unwrap();
+
+    let lines = crate::app::App::load_meta_lines(&link);
+    let joined = lines.join("\n");
+    assert!(
+        joined.contains("Target"),
+        "should have Target line: {joined}"
+    );
+    assert!(joined.contains("exists"), "should show exists: {joined}");
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+/// Given: a dangling symlink (target does not exist)
+/// When: load_meta_lines is called on the symlink path
+/// Then: the output contains a "Target" line and a "Valid" line showing "dangling"
+#[test]
+#[cfg(unix)]
+fn meta_lines_symlink_dangling_shows_dangling() {
+    let tmp = std::env::temp_dir().join(format!("trek_sl_dangle_{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&tmp);
+    let link = tmp.join("broken.txt");
+    std::os::unix::fs::symlink("/this/path/does/not/exist/anywhere", &link).unwrap();
+
+    let lines = crate::app::App::load_meta_lines(&link);
+    let joined = lines.join("\n");
+    assert!(
+        joined.contains("Target"),
+        "should have Target line: {joined}"
+    );
+    assert!(
+        joined.contains("dangling"),
+        "should show dangling: {joined}"
+    );
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+/// Given: a regular file (not a symlink)
+/// When: load_meta_lines is called
+/// Then: the output contains no "Target" or "Valid" lines
+#[test]
+#[cfg(unix)]
+fn meta_lines_regular_file_has_no_target_line() {
+    let tmp = std::env::temp_dir().join(format!("trek_sl_reg_{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&tmp);
+    let file = tmp.join("plain.txt");
+    std::fs::write(&file, b"data").unwrap();
+
+    let lines = crate::app::App::load_meta_lines(&file);
+    let joined = lines.join("\n");
+    assert!(
+        !joined.contains("Target"),
+        "regular file should have no Target line: {joined}"
+    );
+    assert!(
+        !joined.contains("Valid"),
+        "regular file should have no Valid line: {joined}"
+    );
+    let _ = std::fs::remove_dir_all(&tmp);
+}


### PR DESCRIPTION
## Summary
- Meta card (`m`) for symlinks now shows `Target` (raw stored path, `$HOME` → `~`) and `Valid` (✓ exists / ✗ dangling) after the `Type` line
- Dangling symlinks clearly identified without leaving trek
- Permission errors show `Target    (unreadable)` with no `Valid` line
- Regular files and directories unchanged

## Test plan
- [ ] `cargo test` — all 221 tests pass
- [ ] `cargo clippy -- -D warnings` — no warnings
- [ ] `cargo build --release` — builds clean at v0.38.0
- [ ] Manual: select a valid symlink, press `m` — `Target` and `Valid  ✓  exists` appear after `Type`
- [ ] Manual: create a dangling symlink (`ln -s /nonexistent foo`), press `m` — `Valid  ✗  dangling` shown
- [ ] Manual: symlink with `$HOME` in path — shows `~` abbreviation
- [ ] Manual: select a regular file, press `m` — no `Target` or `Valid` lines present

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)