### PR TITLE
feat(trek): frecency jump list overlay (z key) — v0.39.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.39.0] - 2026-03-24
+
+### Added
+- **`z` — frecency jump list**: press `z` to open a session-scoped overlay listing recently visited directories ranked by frecency (frequency × recency)
+- Overlay auto-populates as you navigate; no manual setup required
+- Score = `visits × recency_weight` where weight is 4× (< 1 hr), 2× (< 24 hr), 1× (< 1 week), 0.5× (older)
+- Type to filter by directory name; `Enter` jumps, `Esc`/`z` closes
+- Yellow border and highlight to distinguish from bookmarks (cyan)
+- Stale entries (directory deleted) show an error message rather than crashing
+- `OpenFrecency` registered in the command palette and `?` help overlay
+
 ## [0.38.0] - 2026-03-24
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trek"
-version = "0.38.0"
+version = "0.39.0"
 edition = "2021"
 rust-version = "1.80"
 description = "A terminal file manager with mouse-resizable panes"

--- a/src/app/frecency.rs
+++ b/src/app/frecency.rs
@@ -1,0 +1,33 @@
+use std::path::PathBuf;
+use std::time::Instant;
+
+/// One entry in the session frecency table.
+#[derive(Debug, Clone)]
+pub struct FrecencyEntry {
+    pub path: PathBuf,
+    pub visits: u32,
+    pub last_visit: Instant,
+}
+
+impl FrecencyEntry {
+    /// Frecency score = visits × recency_weight.
+    ///
+    /// Recency weight is a step function that strongly favours recent visits:
+    /// - Within 1 hour  → 4.0
+    /// - Within 24 hours → 2.0
+    /// - Within 1 week   → 1.0
+    /// - Older           → 0.5
+    pub fn score(&self) -> f64 {
+        let secs = self.last_visit.elapsed().as_secs();
+        let weight = if secs < 3_600 {
+            4.0
+        } else if secs < 86_400 {
+            2.0
+        } else if secs < 604_800 {
+            1.0
+        } else {
+            0.5
+        };
+        self.visits as f64 * weight
+    }
+}

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -4,6 +4,7 @@ use crate::ops::Clipboard;
 use crate::rename::{RenameField, RenamePreviewRow};
 use crate::search::SearchResultGroup;
 use anyhow::Result;
+use frecency::FrecencyEntry;
 use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -13,6 +14,7 @@ mod content;
 mod file_ops;
 mod filter;
 mod find;
+pub mod frecency;
 mod gitignore;
 mod layout;
 mod metadata;
@@ -357,6 +359,18 @@ pub struct App {
     pub dup_input: String,
     /// Source path being duplicated; set when dup_mode is entered.
     pub dup_src: Option<PathBuf>,
+
+    // --- Frecency jump (z) ---
+    /// True while the frecency overlay is open.
+    pub frecency_mode: bool,
+    /// All recorded frecency entries (unsorted, session-scoped).
+    pub frecency_list: Vec<FrecencyEntry>,
+    /// Indices into `frecency_list` after filter + sort, for display.
+    pub frecency_filtered: Vec<usize>,
+    /// Cursor row in the frecency overlay.
+    pub frecency_selected: usize,
+    /// Current filter query typed in the overlay.
+    pub frecency_query: String,
 }
 
 #[derive(Clone)]
@@ -483,6 +497,11 @@ impl App {
             dup_input: String::new(),
             dup_src: None,
             clipboard_inspect_mode: false,
+            frecency_mode: false,
+            frecency_list: Vec::new(),
+            frecency_filtered: Vec::new(),
+            frecency_selected: 0,
+            frecency_query: String::new(),
         };
         app.load_dir();
         Ok(app)

--- a/src/app/navigation.rs
+++ b/src/app/navigation.rs
@@ -128,6 +128,8 @@ impl App {
     /// forward entries (browser-style), appends the new location, and caps
     /// the stack at MAX_HISTORY.
     pub fn push_history(&mut self, new_dir: PathBuf) {
+        // Record destination in the session frecency table.
+        self.record_frecency(new_dir.clone());
         // Save current cursor into the current history entry.
         if let Some(e) = self.history.get_mut(self.history_pos) {
             e.selected = self.selected;
@@ -146,6 +148,110 @@ impl App {
             self.history.drain(..drop);
             self.history_pos = self.history_pos.saturating_sub(drop);
         }
+    }
+
+    /// Record a visit to `path` in the session frecency table.
+    pub fn record_frecency(&mut self, path: PathBuf) {
+        if let Some(e) = self.frecency_list.iter_mut().find(|e| e.path == path) {
+            e.visits += 1;
+            e.last_visit = std::time::Instant::now();
+        } else {
+            use crate::app::frecency::FrecencyEntry;
+            self.frecency_list.push(FrecencyEntry {
+                path,
+                visits: 1,
+                last_visit: std::time::Instant::now(),
+            });
+        }
+    }
+
+    /// Open the frecency overlay and build the initial filtered list.
+    pub fn open_frecency(&mut self) {
+        self.frecency_mode = true;
+        self.frecency_query.clear();
+        self.frecency_selected = 0;
+        self.rebuild_frecency_filtered();
+    }
+
+    /// Close the frecency overlay without navigating.
+    pub fn close_frecency(&mut self) {
+        self.frecency_mode = false;
+        self.frecency_query.clear();
+    }
+
+    /// Rebuild `frecency_filtered`: filter by query, sort by score descending.
+    pub fn rebuild_frecency_filtered(&mut self) {
+        let q = self.frecency_query.to_lowercase();
+        let mut scored: Vec<(usize, f64)> = self
+            .frecency_list
+            .iter()
+            .enumerate()
+            .filter(|(_, e)| {
+                if q.is_empty() {
+                    return true;
+                }
+                let name = e
+                    .path
+                    .file_name()
+                    .map(|n| n.to_string_lossy().to_lowercase())
+                    .unwrap_or_default();
+                name.contains(&q)
+            })
+            .map(|(i, e)| (i, e.score()))
+            .collect();
+        scored.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+        self.frecency_filtered = scored.into_iter().map(|(i, _)| i).collect();
+        if self.frecency_selected >= self.frecency_filtered.len() {
+            self.frecency_selected = self.frecency_filtered.len().saturating_sub(1);
+        }
+    }
+
+    pub fn frecency_push_char(&mut self, c: char) {
+        self.frecency_query.push(c);
+        self.frecency_selected = 0;
+        self.rebuild_frecency_filtered();
+    }
+
+    pub fn frecency_pop_char(&mut self) {
+        self.frecency_query.pop();
+        self.frecency_selected = 0;
+        self.rebuild_frecency_filtered();
+    }
+
+    pub fn frecency_move_up(&mut self) {
+        if self.frecency_selected > 0 {
+            self.frecency_selected -= 1;
+        }
+    }
+
+    pub fn frecency_move_down(&mut self) {
+        if self.frecency_selected + 1 < self.frecency_filtered.len() {
+            self.frecency_selected += 1;
+        }
+    }
+
+    /// Navigate to the currently selected frecency entry and close the overlay.
+    pub fn confirm_frecency(&mut self) {
+        let idx = match self.frecency_filtered.get(self.frecency_selected) {
+            Some(&i) => i,
+            None => {
+                self.close_frecency();
+                return;
+            }
+        };
+        let dest = self.frecency_list[idx].path.clone();
+        self.close_frecency();
+        if !dest.is_dir() {
+            self.status_message = Some(format!("No longer exists: {}", dest.display()));
+            return;
+        }
+        self.filter_input.clear();
+        self.filter_mode = false;
+        self.push_history(dest.clone());
+        self.cwd = dest;
+        self.selected = 0;
+        self.current_scroll = 0;
+        self.load_dir();
     }
 
     /// Go back to the previous location in the jump history stack.

--- a/src/app/palette.rs
+++ b/src/app/palette.rs
@@ -59,6 +59,7 @@ pub enum ActionId {
     BeginDup,
     BeginSymlink,
     InspectClipboard,
+    OpenFrecency,
     ShowHelp,
     Quit,
 }
@@ -337,6 +338,11 @@ pub static PALETTE_ACTIONS: &[PaletteAction] = &[
         id: ActionId::InspectClipboard,
         name: "Inspect clipboard contents",
         keys: "F",
+    },
+    PaletteAction {
+        id: ActionId::OpenFrecency,
+        name: "Open frecency jump list (auto-ranked recent dirs)",
+        keys: "z",
     },
     PaletteAction {
         id: ActionId::ShowHelp,

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -2922,3 +2922,106 @@ fn meta_lines_regular_file_has_no_target_line() {
     );
     let _ = std::fs::remove_dir_all(&tmp);
 }
+
+/// Given: a freshly created App
+/// When: record_frecency is called with a path
+/// Then: frecency_list has one entry for that path with visits = 1
+#[test]
+fn record_frecency_adds_new_entry() {
+    let tmp = std::env::temp_dir().join(format!("trek_frec_new_{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&tmp);
+    let mut app = make_app_at(&tmp);
+    let sub = tmp.join("alpha");
+    std::fs::create_dir_all(&sub).unwrap();
+    app.record_frecency(sub.clone());
+    let entry = app.frecency_list.iter().find(|e| e.path == sub);
+    assert!(
+        entry.is_some(),
+        "frecency_list should contain the recorded path"
+    );
+    assert_eq!(entry.unwrap().visits, 1);
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+/// Given: a path already in frecency_list with visits = 1
+/// When: record_frecency is called again for the same path
+/// Then: visits increments to 2 (no duplicate entry)
+#[test]
+fn record_frecency_increments_existing_entry() {
+    let tmp = std::env::temp_dir().join(format!("trek_frec_inc_{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&tmp);
+    let mut app = make_app_at(&tmp);
+    let sub = tmp.join("beta");
+    std::fs::create_dir_all(&sub).unwrap();
+    app.record_frecency(sub.clone());
+    app.record_frecency(sub.clone());
+    let count = app.frecency_list.iter().filter(|e| e.path == sub).count();
+    assert_eq!(count, 1, "should not create duplicate entries");
+    let entry = app.frecency_list.iter().find(|e| e.path == sub).unwrap();
+    assert_eq!(entry.visits, 2);
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+/// Given: frecency_list has two entries
+/// When: open_frecency is called
+/// Then: frecency_mode is true, frecency_filtered is populated sorted by score
+#[test]
+fn open_frecency_sets_mode_and_builds_filtered() {
+    let tmp = std::env::temp_dir().join(format!("trek_frec_open_{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&tmp);
+    let mut app = make_app_at(&tmp);
+    let a = tmp.join("aaa");
+    let b = tmp.join("bbb");
+    std::fs::create_dir_all(&a).unwrap();
+    std::fs::create_dir_all(&b).unwrap();
+    app.record_frecency(a.clone());
+    app.record_frecency(a.clone()); // visits=2, scores higher
+    app.record_frecency(b.clone()); // visits=1
+    app.open_frecency();
+    assert!(app.frecency_mode);
+    assert_eq!(app.frecency_filtered.len(), 2);
+    // First entry should be 'aaa' (higher score)
+    let first_path = &app.frecency_list[app.frecency_filtered[0]].path;
+    assert_eq!(first_path, &a);
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+/// Given: frecency overlay is open with entries
+/// When: close_frecency is called
+/// Then: frecency_mode is false and query is cleared
+#[test]
+fn close_frecency_clears_mode_and_query() {
+    let tmp = std::env::temp_dir().join(format!("trek_frec_close_{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&tmp);
+    let mut app = make_app_at(&tmp);
+    app.frecency_mode = true;
+    app.frecency_query = "abc".to_string();
+    app.close_frecency();
+    assert!(!app.frecency_mode);
+    assert!(app.frecency_query.is_empty());
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+/// Given: frecency overlay open with entries containing "src" in name
+/// When: frecency_push_char filters by "src"
+/// Then: only matching entries appear in frecency_filtered
+#[test]
+fn frecency_push_char_filters_by_name() {
+    let tmp = std::env::temp_dir().join(format!("trek_frec_filt_{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&tmp);
+    let mut app = make_app_at(&tmp);
+    let alpha = tmp.join("alpha");
+    let beta = tmp.join("beta");
+    std::fs::create_dir_all(&alpha).unwrap();
+    std::fs::create_dir_all(&beta).unwrap();
+    app.record_frecency(alpha.clone());
+    app.record_frecency(beta.clone());
+    app.open_frecency();
+    // "lph" is only in "alpha", not "beta"
+    app.frecency_push_char('l');
+    app.frecency_push_char('p');
+    assert_eq!(app.frecency_filtered.len(), 1);
+    let matched = &app.frecency_list[app.frecency_filtered[0]].path;
+    assert_eq!(matched, &alpha);
+    let _ = std::fs::remove_dir_all(&tmp);
+}

--- a/src/args.rs
+++ b/src/args.rs
@@ -78,6 +78,7 @@ pub fn print_help() {
     println!("    '<c>        Jump to mark 'c' — navigate to the marked directory");
     println!("    [           Scroll preview up 5 lines  ]  Scroll preview down 5 lines");
     println!("    /           Fuzzy search       Ctrl+F      Content search (rg)");
+    println!("    z           Frecency jump list (auto-ranked recent dirs)");
     println!("    y / Y       Yank relative / absolute path");
     println!(
         "    A           Yank path (pick format: r=relative  a=absolute  f=filename  p=parent dir)"

--- a/src/events.rs
+++ b/src/events.rs
@@ -219,6 +219,17 @@ pub fn run(
                         }
                         _ => {}
                     }
+                } else if app.frecency_mode {
+                    match key.code {
+                        KeyCode::Esc => app.close_frecency(),
+                        KeyCode::Char('z') => app.close_frecency(),
+                        KeyCode::Enter => app.confirm_frecency(),
+                        KeyCode::Up | KeyCode::Char('k') => app.frecency_move_up(),
+                        KeyCode::Down | KeyCode::Char('j') => app.frecency_move_down(),
+                        KeyCode::Backspace => app.frecency_pop_char(),
+                        KeyCode::Char(c) => app.frecency_push_char(c),
+                        _ => {}
+                    }
                 } else if app.mark_set_mode {
                     match key.code {
                         KeyCode::Char(c) if c.is_alphabetic() => app.set_mark(c),
@@ -276,6 +287,7 @@ pub fn run(
                         KeyCode::Char('U') => app.toggle_preview_wrap(),
                         KeyCode::Char('N') => app.toggle_dir_counts(),
                         KeyCode::Char('F') => app.open_clipboard_inspect(),
+                        KeyCode::Char('z') => app.open_frecency(),
                         KeyCode::Char('P') => app.begin_chmod(),
                         KeyCode::Char('R') => app.refresh_git_status(),
                         KeyCode::Char('?') => app.show_help = true,
@@ -492,6 +504,7 @@ fn execute_palette_action(
         ActionId::BeginDup => app.begin_dup(),
         ActionId::BeginSymlink => app.begin_symlink(),
         ActionId::InspectClipboard => app.open_clipboard_inspect(),
+        ActionId::OpenFrecency => app.open_frecency(),
         ActionId::ShowHelp => app.show_help = true,
         // Quit appears in the palette for discoverability but cannot break out
         // of the event loop from here — use q directly.

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -199,6 +199,11 @@ pub fn draw(f: &mut Frame, app: &mut App) {
         draw_bookmark_overlay(f, app, size);
     }
 
+    // Frecency jump overlay.
+    if app.frecency_mode {
+        draw_frecency_overlay(f, app, size);
+    }
+
     // Yank picker overlay.
     if app.yank_picker_mode {
         draw_yank_picker(f, app, size);
@@ -1474,6 +1479,141 @@ fn draw_bookmark_overlay(f: &mut Frame, app: &App, size: Rect) {
     f.render_widget(hint, inner_chunks[1]);
 }
 
+/// Render the frecency jump list as a centred overlay.
+fn draw_frecency_overlay(f: &mut Frame, app: &App, size: Rect) {
+    let max_visible: usize = 12;
+    let row_count = app.frecency_filtered.len().max(1).min(max_visible);
+    let width = 62u16.min(size.width.saturating_sub(4));
+    let height = (row_count as u16 + 4)
+        .min(size.height.saturating_sub(4))
+        .max(6);
+    let x = (size.width.saturating_sub(width)) / 2;
+    let y = (size.height.saturating_sub(height)) / 2;
+    let area = Rect::new(x, y, width, height);
+
+    f.render_widget(Clear, area);
+
+    let title = if app.frecency_query.is_empty() {
+        " Frecency ".to_string()
+    } else {
+        format!(" Frecency  {} ", app.frecency_query)
+    };
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Yellow))
+        .title(Span::styled(
+            title,
+            Style::default()
+                .fg(Color::White)
+                .add_modifier(Modifier::BOLD),
+        ));
+
+    let inner = block.inner(area);
+    f.render_widget(block, area);
+
+    let visible_height = inner.height.saturating_sub(1) as usize; // -1 for hint row
+    let name_col = 16usize;
+
+    if app.frecency_filtered.is_empty() {
+        let msg = if app.frecency_list.is_empty() {
+            "  Navigate to a directory to start tracking"
+        } else {
+            "  No matches"
+        };
+        let para = Paragraph::new(Line::from(Span::styled(
+            msg,
+            Style::default().fg(Color::DarkGray),
+        )));
+        f.render_widget(para, inner);
+        return;
+    }
+
+    let scroll = if app.frecency_selected >= visible_height {
+        app.frecency_selected - visible_height + 1
+    } else {
+        0
+    };
+
+    let home = std::env::var("HOME").unwrap_or_default();
+    let path_width = (inner.width as usize).saturating_sub(name_col + 2);
+
+    let items: Vec<ListItem> = app
+        .frecency_filtered
+        .iter()
+        .enumerate()
+        .skip(scroll)
+        .take(visible_height)
+        .map(|(display_idx, &real_idx)| {
+            let entry = &app.frecency_list[real_idx];
+            let is_selected = display_idx + scroll == app.frecency_selected;
+
+            let short = entry
+                .path
+                .file_name()
+                .map(|n| n.to_string_lossy().into_owned())
+                .unwrap_or_else(|| entry.path.to_string_lossy().into_owned());
+            let short_col = truncate_with_ellipsis(&short, name_col);
+
+            let full = entry.path.to_string_lossy().into_owned();
+            let display_path = if !home.is_empty() && full.starts_with(&home) {
+                format!("~{}", &full[home.len()..])
+            } else {
+                full
+            };
+            let path_col = truncate_with_ellipsis(&display_path, path_width);
+
+            if is_selected {
+                let style = Style::default()
+                    .fg(Color::White)
+                    .bg(Color::Blue)
+                    .add_modifier(Modifier::BOLD);
+                ListItem::new(Line::from(vec![
+                    Span::styled(format!(" {:<width$}", short_col, width = name_col), style),
+                    Span::styled(path_col, style),
+                ]))
+            } else {
+                ListItem::new(Line::from(vec![
+                    Span::styled(
+                        format!(" {:<width$}", short_col, width = name_col),
+                        Style::default().fg(Color::Yellow),
+                    ),
+                    Span::raw(path_col),
+                ]))
+            }
+        })
+        .collect();
+
+    let hint = Paragraph::new(Line::from(vec![
+        Span::styled(
+            "  Enter",
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(": jump  ", Style::default().fg(Color::DarkGray)),
+        Span::styled(
+            "Esc",
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(
+            ": close  type to filter",
+            Style::default().fg(Color::DarkGray),
+        ),
+    ]));
+
+    let inner_chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Min(1), Constraint::Length(1)])
+        .split(inner);
+
+    let list = List::new(items);
+    f.render_widget(list, inner_chunks[0]);
+    f.render_widget(hint, inner_chunks[1]);
+}
+
 /// Render the find prompt in the status bar.
 fn draw_find_bar(f: &mut Frame, app: &App, area: Rect) {
     if let Some(ref err) = app.find_error {
@@ -1790,7 +1930,7 @@ fn draw_yank_picker(f: &mut Frame, app: &App, size: Rect) {
 
 fn draw_help_overlay(f: &mut Frame, size: Rect) {
     let width = 60u16.min(size.width.saturating_sub(4));
-    let height = 84u16.min(size.height.saturating_sub(4));
+    let height = 86u16.min(size.height.saturating_sub(4));
     let x = (size.width.saturating_sub(width)) / 2;
     let y = (size.height.saturating_sub(height)) / 2;
     let area = Rect::new(x, y, width, height);
@@ -1829,6 +1969,7 @@ fn draw_help_overlay(f: &mut Frame, size: Rect) {
         key_line("Ctrl+P", "Recursive filename find"),
         key_line("b", "Bookmark current directory"),
         key_line("B", "Open bookmark picker"),
+        key_line("z", "Open frecency jump list (auto-ranked recent dirs)"),
         Line::from(""),
         // ── View ────────────────────────────────────────────────────────────
         section_header("View"),


### PR DESCRIPTION
## Summary
- `z` opens a session-scoped frecency overlay listing recently visited directories ranked by score (frequency × recency weight)
- Score weights: 4× within 1 hr, 2× within 24 hr, 1× within 1 week, 0.5× older
- Type to filter by directory name; `Enter` jumps, `Esc`/`z` closes
- Yellow border/highlight to distinguish from bookmarks (cyan)
- Stale entries (directory deleted) show error rather than crashing
- `OpenFrecency` in command palette and `?` help overlay

## Test plan
- [ ] `cargo test` — all 226 tests pass
- [ ] `cargo clippy -- -D warnings` — no warnings
- [ ] `cargo build --release` — builds clean at v0.39.0
- [ ] Manual: press `z` at startup — empty overlay with hint message
- [ ] Manual: navigate to 3+ dirs, press `z` — overlay shows them ranked
- [ ] Manual: type in overlay — filters by directory name
- [ ] Manual: `Enter` on highlighted entry — navigates and closes
- [ ] Manual: `Esc` or `z` — closes without navigating
- [ ] Manual: delete a frecency target, open overlay, press `Enter` — shows error message
- [ ] Manual: `z` listed in `?` help overlay and command palette

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)