### PR TITLE
feat(trek): add archive extraction (Z key) — v0.44.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.44.0] - 2026-03-24
+
+### Added
+- **`Z` — archive extraction**: press `Z` on any recognized archive to extract it into the current directory
+- Supported formats: `.tar`, `.tar.gz`/`.tgz`, `.tar.bz2`/`.tbz2`, `.tar.xz`/`.txz`, `.tar.zst`/`.tzst`, `.zip`/`.jar`/`.war`/`.ear`, `.gz`, `.7z`
+- A confirmation bar shows `[ Extract ] "filename" → ./ [y/Enter · Esc to cancel]` before acting
+- On success: listing refreshes and status bar shows `"Extracted: <name>"`
+- On failure: status bar shows `"Extract failed: <first stderr line>"`
+- `Z` on a non-archive file shows `"Not an archive"` and does nothing
+- Graceful error messages when `unzip` or `7z` are not installed
+- `BeginExtract` registered in the command palette (`Z`) and `?` help overlay
+
 ## [0.43.0] - 2026-03-24
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -586,7 +586,7 @@ dependencies = [
 
 [[package]]
 name = "trek"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trek"
-version = "0.43.0"
+version = "0.44.0"
 edition = "2021"
 rust-version = "1.80"
 description = "A terminal file manager with mouse-resizable panes"

--- a/src/app/file_ops.rs
+++ b/src/app/file_ops.rs
@@ -514,4 +514,47 @@ impl App {
     pub fn close_clipboard_inspect(&mut self) {
         self.clipboard_inspect_mode = false;
     }
+
+    // --- Archive extraction (Z) ---
+
+    /// Begin an extraction confirmation for the currently selected entry.
+    ///
+    /// Shows `"Not an archive"` if the entry is not a recognized archive type.
+    pub fn begin_extract(&mut self) {
+        if let Some(entry) = self.entries.get(self.selected) {
+            if crate::archive::is_archive(&entry.path) {
+                self.pending_extract = Some(entry.path.clone());
+            } else {
+                self.status_message = Some("Not an archive".to_string());
+            }
+        }
+    }
+
+    /// Run the extraction after the user confirms with y/Enter.
+    pub fn confirm_extract(&mut self) {
+        let path = match self.pending_extract.take() {
+            Some(p) => p,
+            None => return,
+        };
+        let name = path
+            .file_name()
+            .map(|n| n.to_string_lossy().into_owned())
+            .unwrap_or_else(|| path.to_string_lossy().into_owned());
+        match crate::archive::extract_archive(&path, &self.cwd) {
+            Ok(()) => {
+                self.status_message = Some(format!("Extracted: {}", name));
+                self.load_dir();
+                self.git_status = crate::git::GitStatus::load(&self.cwd);
+            }
+            Err(e) => {
+                self.status_message = Some(format!("Extract failed: {}", e));
+            }
+        }
+    }
+
+    /// Cancel the extraction without touching the filesystem.
+    pub fn cancel_extract(&mut self) {
+        self.pending_extract = None;
+        self.status_message = Some("Extract cancelled".to_string());
+    }
 }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -202,6 +202,8 @@ pub struct App {
     pub clipboard: Option<Clipboard>,
     /// Paths pending deletion (non-empty while confirmation prompt is shown).
     pub pending_delete: Vec<PathBuf>,
+    /// Archive path awaiting extraction confirmation (Some while prompt is shown).
+    pub pending_extract: Option<PathBuf>,
     /// The most recent group of trashed items, available for undo with `u`.
     pub last_trashed: Vec<crate::trash::TrashedEntry>,
     /// True while the mkdir name input bar is open.
@@ -449,6 +451,7 @@ impl App {
             highlighter: Highlighter::new(),
             clipboard: None,
             pending_delete: Vec::new(),
+            pending_extract: None,
             last_trashed: Vec::new(),
             mkdir_mode: false,
             mkdir_input: String::new(),

--- a/src/app/palette.rs
+++ b/src/app/palette.rs
@@ -58,6 +58,7 @@ pub enum ActionId {
     GlobSelect,
     BeginDup,
     BeginSymlink,
+    BeginExtract,
     ToggleGitLogPreview,
     CompareFiles,
     ToggleHexView,
@@ -351,6 +352,11 @@ pub static PALETTE_ACTIONS: &[PaletteAction] = &[
         id: ActionId::BeginSymlink,
         name: "Create symlink to selected entry",
         keys: "L",
+    },
+    PaletteAction {
+        id: ActionId::BeginExtract,
+        name: "Extract archive to current directory",
+        keys: "Z",
     },
     PaletteAction {
         id: ActionId::InspectClipboard,

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -3280,3 +3280,53 @@ fn toggle_meta_preview_clears_hex_view() {
     assert!(!app.hex_view_mode);
     let _ = std::fs::remove_dir_all(&tmp);
 }
+
+/// Given: the selected entry is a .tar.gz archive
+/// When: begin_extract is called
+/// Then: pending_extract is set to the archive path
+#[test]
+fn begin_extract_on_archive_sets_pending() {
+    let tmp = std::env::temp_dir().join(format!("trek_ex_arc_{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&tmp);
+    std::fs::write(tmp.join("data.tar.gz"), b"fake").unwrap();
+    let mut app = make_app_at(&tmp);
+    app.begin_extract();
+    assert!(app.pending_extract.is_some());
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+/// Given: the selected entry is a plain .rs file
+/// When: begin_extract is called
+/// Then: pending_extract remains None and status_message is set
+#[test]
+fn begin_extract_on_non_archive_shows_status() {
+    let tmp = std::env::temp_dir().join(format!("trek_ex_non_{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&tmp);
+    std::fs::write(tmp.join("main.rs"), b"fn main() {}").unwrap();
+    let mut app = make_app_at(&tmp);
+    app.begin_extract();
+    assert!(app.pending_extract.is_none());
+    assert!(app.status_message.is_some());
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+/// Given: pending_extract is set
+/// When: cancel_extract is called
+/// Then: pending_extract is None and status_message mentions cancel
+#[test]
+fn cancel_extract_clears_pending() {
+    let tmp = std::env::temp_dir().join(format!("trek_ex_can_{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&tmp);
+    std::fs::write(tmp.join("data.tar.gz"), b"fake").unwrap();
+    let mut app = make_app_at(&tmp);
+    app.begin_extract();
+    assert!(app.pending_extract.is_some());
+    app.cancel_extract();
+    assert!(app.pending_extract.is_none());
+    let msg = app.status_message.clone().unwrap_or_default();
+    assert!(
+        msg.to_lowercase().contains("cancel"),
+        "expected cancel message: {msg}"
+    );
+    let _ = std::fs::remove_dir_all(&tmp);
+}

--- a/src/archive.rs
+++ b/src/archive.rs
@@ -153,6 +153,60 @@ fn truncate_if_needed(mut lines: Vec<String>) -> Vec<String> {
 
 // ── Public API ─────────────────────────────────────────────────────────────────
 
+/// Returns `true` if `path` has a recognized archive extension.
+pub fn is_archive(path: &Path) -> bool {
+    archive_ext(path).is_some()
+}
+
+/// Extract the archive at `path` into `dest_dir`.
+///
+/// Returns `Ok(())` on success or `Err(message)` with a human-readable
+/// description of what went wrong.
+pub fn extract_archive(path: &Path, dest_dir: &Path) -> Result<(), String> {
+    let ext = archive_ext(path).ok_or_else(|| "not a recognized archive format".to_string())?;
+    let path_str = path
+        .to_str()
+        .ok_or_else(|| "path is not valid UTF-8".to_string())?;
+    let dest_str = dest_dir
+        .to_str()
+        .ok_or_else(|| "destination path is not valid UTF-8".to_string())?;
+
+    match ext {
+        ArchiveExt::Tar => run_extract("tar", &["-xf", path_str, "-C", dest_str]),
+        ArchiveExt::TarGz => run_extract("tar", &["-xzf", path_str, "-C", dest_str]),
+        ArchiveExt::TarBz2 => run_extract("tar", &["-xjf", path_str, "-C", dest_str]),
+        ArchiveExt::TarXz => run_extract("tar", &["-xJf", path_str, "-C", dest_str]),
+        ArchiveExt::TarZst => run_extract("tar", &["-x", "--zstd", "-f", path_str, "-C", dest_str]),
+        ArchiveExt::Zip => {
+            if !command_exists("unzip") {
+                return Err("unzip not found — install it to extract .zip files".to_string());
+            }
+            run_extract("unzip", &["-n", path_str, "-d", dest_str])
+        }
+        ArchiveExt::Gz => run_extract("gunzip", &["-k", "-f", path_str]),
+        ArchiveExt::SevenZip => {
+            if !command_exists("7z") {
+                return Err("7z not found — install p7zip to extract .7z files".to_string());
+            }
+            run_extract("7z", &["x", path_str, &format!("-o{}", dest_str), "-y"])
+        }
+    }
+}
+
+/// Run an extraction command; returns `Ok(())` on success or `Err(first stderr line)`.
+fn run_extract(bin: &str, args: &[&str]) -> Result<(), String> {
+    let output = Command::new(bin)
+        .args(args)
+        .output()
+        .map_err(|e| format!("{} not found: {}", bin, e))?;
+    if output.status.success() {
+        Ok(())
+    } else {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        Err(stderr.lines().next().unwrap_or("unknown error").to_string())
+    }
+}
+
 /// Returns `Some(lines)` if `path` is a recognized archive and the listing
 /// tool is available. Returns `None` to signal "fall back to normal preview."
 pub fn try_list_archive(path: &Path) -> Option<Vec<String>> {

--- a/src/args.rs
+++ b/src/args.rs
@@ -106,6 +106,7 @@ pub fn print_help() {
     println!("    t           New empty file         M           Make new directory");
     println!("    L           Create symlink to selected entry (Unix only)");
     println!("    W           Duplicate selected entry in place (editable name bar)");
+    println!("    Z           Extract archive to current directory");
     println!("    X           Delete all selected");
     println!("    :           Open command palette");
     println!("    ?           Show help overlay  q           Quit");

--- a/src/events.rs
+++ b/src/events.rs
@@ -51,6 +51,13 @@ pub fn run(
                         KeyCode::Char('D') => app.confirm_permanent_delete(),
                         _ => app.cancel_delete(),
                     }
+                } else if app.pending_extract.is_some() {
+                    match key.code {
+                        KeyCode::Char('y') | KeyCode::Char('Y') | KeyCode::Enter => {
+                            app.confirm_extract()
+                        }
+                        _ => app.cancel_extract(),
+                    }
                 } else if app.mkdir_mode {
                     match key.code {
                         KeyCode::Esc => app.cancel_mkdir(),
@@ -318,6 +325,7 @@ pub fn run(
                         KeyCode::Char('t') => app.begin_touch(),
                         KeyCode::Char('W') => app.begin_dup(),
                         KeyCode::Char('L') => app.begin_symlink(),
+                        KeyCode::Char('Z') => app.begin_extract(),
                         // Quick single-file rename
                         KeyCode::Char('n') | KeyCode::F(2) => app.begin_quick_rename(),
                         KeyCode::Char('u') => app.undo_trash(),
@@ -509,6 +517,7 @@ fn execute_palette_action(
         ActionId::GlobSelect => app.begin_glob_select(),
         ActionId::BeginDup => app.begin_dup(),
         ActionId::BeginSymlink => app.begin_symlink(),
+        ActionId::BeginExtract => app.begin_extract(),
         ActionId::InspectClipboard => app.open_clipboard_inspect(),
         ActionId::OpenFrecency => app.open_frecency(),
         ActionId::ShowHelp => app.show_help = true,

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -99,6 +99,8 @@ pub fn draw(f: &mut Frame, app: &mut App) {
         draw_rename_bar(f, app, bottom_area);
     } else if !app.pending_delete.is_empty() {
         draw_delete_confirm_bar(f, app, bottom_area);
+    } else if let Some(ref path) = app.pending_extract {
+        draw_extract_bar(f, bottom_area, path);
     } else if app.quick_rename_mode {
         draw_quick_rename_bar(f, app, bottom_area);
     } else if app.path_mode {
@@ -327,6 +329,28 @@ fn draw_filter_bar(f: &mut Frame, app: &App, area: Rect) {
         ),
     ]))
     .block(Block::default().borders(Borders::TOP));
+    f.render_widget(para, area);
+}
+
+fn draw_extract_bar(f: &mut Frame, area: Rect, path: &std::path::Path) {
+    let name = path
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_else(|| path.to_string_lossy().into_owned());
+    let para = Paragraph::new(Line::from(vec![
+        Span::styled(
+            " Extract ",
+            Style::default()
+                .fg(Color::Black)
+                .bg(Color::LightGreen)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::raw(format!("  \"{}\" → ./   ", name)),
+        Span::styled("[y/Enter]", Style::default().fg(Color::Green)),
+        Span::raw("confirm  "),
+        Span::styled("[Esc]", Style::default().fg(Color::DarkGray)),
+        Span::styled("cancel", Style::default().fg(Color::DarkGray)),
+    ]));
     f.render_widget(para, area);
 }
 
@@ -1942,7 +1966,7 @@ fn draw_yank_picker(f: &mut Frame, app: &App, size: Rect) {
 
 fn draw_help_overlay(f: &mut Frame, size: Rect) {
     let width = 60u16.min(size.width.saturating_sub(4));
-    let height = 92u16.min(size.height.saturating_sub(4));
+    let height = 94u16.min(size.height.saturating_sub(4));
     let x = (size.width.saturating_sub(width)) / 2;
     let y = (size.height.saturating_sub(height)) / 2;
     let area = Rect::new(x, y, width, height);
@@ -2025,6 +2049,7 @@ fn draw_help_overlay(f: &mut Frame, size: Rect) {
         key_line("t", "New file (touch — create empty file)"),
         key_line("W", "Duplicate selected entry in place"),
         key_line("L", "Create symlink to selected entry"),
+        key_line("Z", "Extract archive to current directory"),
         key_line("M", "Make new directory"),
         Line::from(""),
         // ── Yank & Misc ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Press `Z` on any recognized archive to extract it into the current directory
- Supported: `.tar`, `.tar.gz`, `.tar.bz2`, `.tar.xz`, `.tar.zst`, `.zip`/`.jar`/`.war`/`.ear`, `.gz`, `.7z`
- Confirmation bar shown before acting; `y`/`Enter` to confirm, `Esc` to cancel
- Listing refreshes on success; graceful error messages on failure or missing tools

## Test plan
- [ ] All 243 tests pass (`cargo test`)
- [ ] `cargo clippy -- -D warnings` clean
- [ ] `cargo build --release` succeeds
- [ ] `Z` on `.tar.gz` shows confirmation prompt with filename
- [ ] `y`/`Enter` extracts; `Esc` cancels
- [ ] `Z` on non-archive file shows `"Not an archive"`
- [ ] Command palette lists `BeginExtract` with `Z` hint
- [ ] `?` help overlay shows `Z` binding

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)