### PR TITLE
feat(trek): persist cwd and marks across restarts — v0.45.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.45.0] - 2026-03-24
+
+### Added
+- **Session persistence**: Trek now saves `cwd` and all marks to `~/.local/share/trek/session` (or `$XDG_DATA_HOME/trek/session`) on clean exit, and restores them on the next launch
+- Marks (`\`a`–`\`z`, `\`A`–`\`Z`) survive restarts — no need to re-navigate and re-set them
+- If Trek is launched with an explicit path argument, the saved cwd is ignored (explicit always wins)
+- Saved paths that no longer exist are silently skipped — Trek starts without them
+- Write failures on quit are non-fatal — Trek never crashes due to a failed session save
+- Follows the same XDG-aware, no-new-dependencies pattern as `src/bookmarks.rs`
+
 ## [0.44.0] - 2026-03-24
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -586,7 +586,7 @@ dependencies = [
 
 [[package]]
 name = "trek"
-version = "0.44.0"
+version = "0.45.0"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trek"
-version = "0.44.0"
+version = "0.45.0"
 edition = "2021"
 rust-version = "1.80"
 description = "A terminal file manager with mouse-resizable panes"

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -3330,3 +3330,100 @@ fn cancel_extract_clears_pending() {
     );
     let _ = std::fs::remove_dir_all(&tmp);
 }
+
+// ── session persistence tests (issue #87) ────────────────────────────────────
+
+use std::sync::Mutex;
+
+/// Serializes session tests that mutate XDG_DATA_HOME.
+static SESSION_LOCK: Mutex<()> = Mutex::new(());
+
+fn with_temp_session<F: FnOnce()>(f: F) {
+    let _guard = SESSION_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    static COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let n = COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let tmp = std::env::temp_dir().join(format!("trek_sess_{}_{}", std::process::id(), n));
+    let _ = std::fs::create_dir_all(&tmp);
+    let prev = std::env::var_os("XDG_DATA_HOME");
+    std::env::set_var("XDG_DATA_HOME", &tmp);
+    f();
+    match prev {
+        Some(v) => std::env::set_var("XDG_DATA_HOME", v),
+        None => std::env::remove_var("XDG_DATA_HOME"),
+    }
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+/// Given: no session file exists
+/// When: session::load() is called
+/// Then: returns empty session without panicking
+#[test]
+fn session_load_returns_empty_when_no_file() {
+    with_temp_session(|| {
+        let s = crate::session::load();
+        assert!(s.cwd.is_none());
+        assert!(s.marks.is_empty());
+    });
+}
+
+/// Given: cwd and marks are saved
+/// When: session::load() is called
+/// Then: cwd and marks are restored correctly
+#[test]
+fn session_save_then_load_restores_cwd_and_marks() {
+    with_temp_session(|| {
+        let tmp = std::env::temp_dir();
+        let marks = {
+            let mut m = std::collections::HashMap::new();
+            m.insert('a', tmp.clone());
+            m
+        };
+        crate::session::save(&tmp, &marks).unwrap();
+        let s = crate::session::load();
+        assert_eq!(s.cwd, Some(tmp.clone()));
+        assert_eq!(s.marks.get(&'a'), Some(&tmp));
+    });
+}
+
+/// Given: session file contains a cwd that no longer exists
+/// When: session::load() is called
+/// Then: cwd is None (silently skipped)
+#[test]
+fn session_load_skips_missing_cwd() {
+    with_temp_session(|| {
+        let marks = std::collections::HashMap::new();
+        let gone = std::path::PathBuf::from("/tmp/__trek_gone_dir_that_does_not_exist__");
+        crate::session::save(&gone, &marks).unwrap();
+        let s = crate::session::load();
+        assert!(s.cwd.is_none());
+    });
+}
+
+/// Given: session file contains a mark pointing to a deleted path
+/// When: session::load() is called
+/// Then: that mark is silently omitted
+#[test]
+fn session_load_skips_missing_mark_paths() {
+    with_temp_session(|| {
+        let tmp = std::env::temp_dir();
+        let marks = {
+            let mut m = std::collections::HashMap::new();
+            m.insert('z', std::path::PathBuf::from("/tmp/__trek_no_such_dir__"));
+            m
+        };
+        crate::session::save(&tmp, &marks).unwrap();
+        let s = crate::session::load();
+        assert!(s.marks.get(&'z').is_none());
+    });
+}
+
+/// Given: session_path() is called with XDG_DATA_HOME set
+/// When: the path is inspected
+/// Then: it ends with trek/session
+#[test]
+fn session_path_ends_with_trek_session() {
+    with_temp_session(|| {
+        let p = crate::session::session_path();
+        assert!(p.ends_with("trek/session"), "got: {}", p.display());
+    });
+}

--- a/src/events.rs
+++ b/src/events.rs
@@ -29,7 +29,14 @@ pub fn run(
     terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
     start_dir: Option<PathBuf>,
 ) -> Result<PathBuf> {
-    let mut app = App::new(start_dir)?;
+    // Restore previous session if no explicit start directory was given.
+    let session = crate::session::load();
+    let effective_start = start_dir.or(session.cwd);
+
+    let mut app = App::new(effective_start)?;
+
+    // Repopulate marks from the saved session.
+    app.marks = session.marks;
 
     loop {
         terminal.draw(|f| crate::ui::draw(f, &mut app))?;
@@ -445,6 +452,9 @@ pub fn run(
             _ => {}
         }
     }
+    // Save session on clean exit. Errors are non-fatal.
+    let _ = crate::session::save(&app.cwd, &app.marks);
+
     Ok(app.cwd)
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ mod icons;
 mod ops;
 mod rename;
 mod search;
+mod session;
 mod shell;
 mod trash;
 mod ui;

--- a/src/session.rs
+++ b/src/session.rs
@@ -1,0 +1,185 @@
+//! Session persistence — save and restore cwd and marks between Trek invocations.
+//!
+//! Stored at `$XDG_DATA_HOME/trek/session` (fallback: `~/.local/share/trek/session`).
+//! Simple `key=value` format; no external dependencies.
+
+use std::collections::HashMap;
+use std::io::{BufRead, Write};
+use std::path::{Path, PathBuf};
+
+pub struct Session {
+    /// Restored working directory (`None` if file missing or dir deleted).
+    pub cwd: Option<PathBuf>,
+    /// Restored mark slots; only entries where the path still exists are included.
+    pub marks: HashMap<char, PathBuf>,
+}
+
+/// Return the path of the session file.
+pub fn session_path() -> PathBuf {
+    let base = std::env::var_os("XDG_DATA_HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| {
+            let home = std::env::var_os("HOME").unwrap_or_default();
+            PathBuf::from(home).join(".local/share")
+        });
+    base.join("trek").join("session")
+}
+
+/// Load the session file. Returns `Session { cwd: None, marks: {} }` if the
+/// file is absent or unreadable — never panics.
+pub fn load() -> Session {
+    let Ok(file) = std::fs::File::open(session_path()) else {
+        return Session {
+            cwd: None,
+            marks: HashMap::new(),
+        };
+    };
+    let mut cwd = None;
+    let mut marks = HashMap::new();
+    for line in std::io::BufReader::new(file).lines().map_while(Result::ok) {
+        let line = line.trim().to_owned();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let Some((key, val)) = line.split_once('=') else {
+            continue;
+        };
+        let path = PathBuf::from(val);
+        if key == "cwd" {
+            if path.is_dir() {
+                cwd = Some(path);
+            }
+        } else if let Some(letter) = key.strip_prefix("mark.") {
+            if let Some(c) = letter.chars().next().filter(|ch| ch.is_alphabetic()) {
+                if path.exists() {
+                    marks.insert(c, path);
+                }
+            }
+        }
+    }
+    Session { cwd, marks }
+}
+
+/// Write `cwd` and `marks` to the session file. Errors are silently ignored
+/// at call sites — a failed save should never crash Trek.
+pub fn save(cwd: &Path, marks: &HashMap<char, PathBuf>) -> std::io::Result<()> {
+    let path = session_path();
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let mut f = std::fs::File::create(&path)?;
+    writeln!(f, "cwd={}", cwd.display())?;
+    let mut sorted: Vec<_> = marks.iter().collect();
+    sorted.sort_by_key(|(c, _)| *c);
+    for (c, p) in sorted {
+        writeln!(f, "mark.{}={}", c, p.display())?;
+    }
+    Ok(())
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    static SESSION_LOCK: Mutex<()> = Mutex::new(());
+
+    fn with_temp_session<F: FnOnce()>(f: F) {
+        let _guard = SESSION_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        static COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+        let n = COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let tmp = std::env::temp_dir().join(format!("trek_sess_mod_{}_{}", std::process::id(), n));
+        let _ = std::fs::create_dir_all(&tmp);
+        let prev = std::env::var_os("XDG_DATA_HOME");
+        std::env::set_var("XDG_DATA_HOME", &tmp);
+        f();
+        match prev {
+            Some(v) => std::env::set_var("XDG_DATA_HOME", v),
+            None => std::env::remove_var("XDG_DATA_HOME"),
+        }
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    /// Given: no session file exists
+    /// When: load() is called
+    /// Then: returns empty session without panicking
+    #[test]
+    fn load_returns_empty_session_when_no_file() {
+        with_temp_session(|| {
+            let s = load();
+            assert!(s.cwd.is_none());
+            assert!(s.marks.is_empty());
+        });
+    }
+
+    /// Given: cwd and a mark are saved
+    /// When: load() is called
+    /// Then: cwd and mark are restored
+    #[test]
+    fn save_then_load_restores_cwd() {
+        with_temp_session(|| {
+            let tmp = std::env::temp_dir();
+            let marks = HashMap::new();
+            save(&tmp, &marks).unwrap();
+            let s = load();
+            assert_eq!(s.cwd, Some(tmp));
+        });
+    }
+
+    /// Given: marks are saved
+    /// When: load() is called
+    /// Then: marks are restored
+    #[test]
+    fn save_then_load_restores_marks() {
+        with_temp_session(|| {
+            let tmp = std::env::temp_dir();
+            let mut marks = HashMap::new();
+            marks.insert('a', tmp.clone());
+            save(&tmp, &marks).unwrap();
+            let s = load();
+            assert_eq!(s.marks.get(&'a'), Some(&tmp));
+        });
+    }
+
+    /// Given: session file contains a cwd that no longer exists
+    /// When: load() is called
+    /// Then: cwd is None
+    #[test]
+    fn load_skips_missing_cwd_directory() {
+        with_temp_session(|| {
+            let gone = PathBuf::from("/tmp/__trek_gone_cwd_test__");
+            let marks = HashMap::new();
+            save(&gone, &marks).unwrap();
+            let s = load();
+            assert!(s.cwd.is_none());
+        });
+    }
+
+    /// Given: session file contains a mark pointing to a deleted path
+    /// When: load() is called
+    /// Then: that mark is omitted
+    #[test]
+    fn load_skips_missing_mark_paths() {
+        with_temp_session(|| {
+            let tmp = std::env::temp_dir();
+            let mut marks = HashMap::new();
+            marks.insert('z', PathBuf::from("/tmp/__trek_no_such_mark__"));
+            save(&tmp, &marks).unwrap();
+            let s = load();
+            assert!(s.marks.get(&'z').is_none());
+        });
+    }
+
+    /// Given: session_path() is called with XDG_DATA_HOME set
+    /// When: the path is inspected
+    /// Then: it ends with trek/session
+    #[test]
+    fn session_path_uses_xdg_data_home() {
+        with_temp_session(|| {
+            let p = session_path();
+            assert!(p.ends_with("trek/session"), "got: {}", p.display());
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- Trek saves `cwd` and all marks to `~/.local/share/trek/session` on clean exit
- Restores them on next launch — marks survive restarts without re-navigation
- Explicit start path (`trek /some/dir`) always overrides the saved cwd
- Missing/deleted paths silently skipped; write failures never crash Trek
- No new crate dependencies — follows the same XDG pattern as `bookmarks.rs`

## Test plan
- [ ] All 254 tests pass (`cargo test`)
- [ ] `cargo clippy -- -D warnings` clean
- [ ] `cargo build --release` succeeds
- [ ] Set a mark, quit Trek, relaunch — mark is immediately usable
- [ ] Last cwd is restored when Trek launched with no args
- [ ] `trek /tmp` ignores saved cwd
- [ ] Deleted directories are silently skipped on restore

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)