### PR TITLE
feat(trek): watch mode — auto-refresh listing on filesystem changes (#90)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.47.0] - 2026-03-24
+
+### Added
+- **`I` — watch mode**: press `I` to toggle watch mode, which auto-refreshes the directory listing whenever the filesystem detects a change to the current directory
+- Uses `crossterm::event::poll` with a 500 ms timeout so the event loop yields frequently enough to catch directory mtime changes without busy-waiting
+- On toggle-on, records the current directory's mtime as a baseline; on toggle-off, clears it
+- On detecting a change, re-runs `load_dir()` and attempts to restore the previously selected entry by name so the cursor doesn't jump unexpectedly
+- Status bar shows `"Watch mode ON — listing auto-refreshes on changes"` / `"Watch mode OFF"` on toggle
+- Path bar gains a cyan `[watch]` badge when watch mode is active
+- `ToggleWatchMode` registered in the command palette (`I`) and `?` help overlay
+
 ## [0.46.0] - 2026-03-24
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trek"
-version = "0.46.0"
+version = "0.47.0"
 edition = "2021"
 rust-version = "1.80"
 description = "A terminal file manager with mouse-resizable panes"

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -192,6 +192,12 @@ pub struct App {
     /// When true the preview pane shows a `du -k -d 1` breakdown of the selected directory.
     pub du_preview_mode: bool,
 
+    // --- Watch mode (I) ---
+    /// When true the event loop polls for directory changes every 500 ms.
+    pub watch_mode: bool,
+    /// Mtime of `cwd` at last load; used to detect changes in watch mode.
+    pub last_dir_mtime: Option<std::time::SystemTime>,
+
     // --- chmod editor (P) ---
     /// True while the chmod input bar is open.
     pub chmod_mode: bool,
@@ -451,6 +457,8 @@ impl App {
             file_compare_mode: false,
             hex_view_mode: false,
             du_preview_mode: false,
+            watch_mode: false,
+            last_dir_mtime: None,
             chmod_mode: false,
             chmod_input: String::new(),
             highlighter: Highlighter::new(),
@@ -592,6 +600,11 @@ impl App {
         // Refresh git status whenever we navigate to a new directory.
         self.git_status = GitStatus::load(&self.cwd);
         self.diff_preview_mode = false;
+
+        // Keep mtime baseline current so watch mode detects the *next* change.
+        if self.watch_mode {
+            self.last_dir_mtime = std::fs::metadata(&self.cwd).and_then(|m| m.modified()).ok();
+        }
 
         self.load_preview();
     }

--- a/src/app/navigation.rs
+++ b/src/app/navigation.rs
@@ -555,4 +555,46 @@ impl App {
             self.status_message = Some("Preview: hidden".to_string());
         }
     }
+
+    // --- Watch mode (I) ---
+
+    /// Toggle watch mode (auto-refresh listing on directory mtime change).
+    pub fn toggle_watch_mode(&mut self) {
+        self.watch_mode = !self.watch_mode;
+        if self.watch_mode {
+            self.last_dir_mtime = std::fs::metadata(&self.cwd).and_then(|m| m.modified()).ok();
+            self.status_message =
+                Some("Watch mode ON — listing auto-refreshes on changes".to_string());
+        } else {
+            self.last_dir_mtime = None;
+            self.status_message = Some("Watch mode OFF".to_string());
+        }
+    }
+
+    /// Check whether the current directory has been modified since the last
+    /// load. Called on each poll timeout when watch mode is active.
+    ///
+    /// Reloads the listing if the mtime changed, preserving the selection by name.
+    pub fn poll_dir_changed(&mut self) {
+        if !self.watch_mode {
+            return;
+        }
+        let current_mtime = std::fs::metadata(&self.cwd).and_then(|m| m.modified()).ok();
+        let changed = match (current_mtime, self.last_dir_mtime) {
+            (Some(current), Some(last)) => current != last,
+            _ => false,
+        };
+        if changed {
+            // Update baseline before load_dir() to avoid re-trigger.
+            self.last_dir_mtime = current_mtime;
+            let selected_name = self.entries.get(self.selected).map(|e| e.name.clone());
+            self.load_dir();
+            if let Some(name) = selected_name {
+                if let Some(idx) = self.entries.iter().position(|e| e.name == name) {
+                    self.selected = idx;
+                    self.load_preview();
+                }
+            }
+        }
+    }
 }

--- a/src/app/palette.rs
+++ b/src/app/palette.rs
@@ -61,6 +61,7 @@ pub enum ActionId {
     BeginExtract,
     ToggleGitLogPreview,
     ToggleDuPreview,
+    ToggleWatchMode,
     CompareFiles,
     ToggleHexView,
     InspectClipboard,
@@ -148,6 +149,11 @@ pub static PALETTE_ACTIONS: &[PaletteAction] = &[
         id: ActionId::ToggleDuPreview,
         name: "Toggle disk usage preview for directory",
         keys: "D",
+    },
+    PaletteAction {
+        id: ActionId::ToggleWatchMode,
+        name: "Toggle watch mode (auto-refresh listing on filesystem changes)",
+        keys: "I",
     },
     PaletteAction {
         id: ActionId::CompareFiles,

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -3493,3 +3493,85 @@ fn toggle_meta_clears_du_preview_mode() {
     assert!(!app.du_preview_mode);
     let _ = std::fs::remove_dir_all(&tmp);
 }
+
+/// Given: watch mode is off
+/// When: toggle_watch_mode is called
+/// Then: watch_mode becomes true and status_message mentions ON
+#[test]
+fn toggle_watch_mode_turns_on() {
+    let tmp = std::env::temp_dir().join(format!("trek_watch_on_{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&tmp);
+    let mut app = make_app_at(&tmp);
+    assert!(!app.watch_mode);
+    app.toggle_watch_mode();
+    assert!(app.watch_mode);
+    let msg = app.status_message.clone().unwrap_or_default();
+    assert!(
+        msg.to_lowercase().contains("on"),
+        "expected ON message: {msg}"
+    );
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+/// Given: watch mode is on
+/// When: toggle_watch_mode is called
+/// Then: watch_mode becomes false and status_message mentions OFF
+#[test]
+fn toggle_watch_mode_turns_off() {
+    let tmp = std::env::temp_dir().join(format!("trek_watch_off_{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&tmp);
+    let mut app = make_app_at(&tmp);
+    app.toggle_watch_mode();
+    assert!(app.watch_mode);
+    app.toggle_watch_mode();
+    assert!(!app.watch_mode);
+    let msg = app.status_message.clone().unwrap_or_default();
+    assert!(
+        msg.to_lowercase().contains("off"),
+        "expected OFF message: {msg}"
+    );
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+/// Given: watch mode is on and a new file appears in the directory
+/// When: poll_dir_changed is called
+/// Then: the new file appears in the listing
+#[test]
+fn poll_dir_changed_detects_new_file() {
+    let tmp = std::env::temp_dir().join(format!("trek_watch_poll_{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&tmp);
+    let mut app = make_app_at(&tmp);
+    app.toggle_watch_mode(); // ON — records initial mtime
+                             // Force mtime to appear changed by backdating last_dir_mtime
+    app.last_dir_mtime = Some(std::time::SystemTime::UNIX_EPOCH);
+    // Create a new file — listing is stale
+    std::fs::write(tmp.join("newfile.txt"), b"x").unwrap();
+    let before = app.entries.len();
+    app.poll_dir_changed();
+    assert!(
+        app.entries.len() > before,
+        "new file should appear after poll"
+    );
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+/// Given: watch mode is off
+/// When: poll_dir_changed is called even with a changed mtime
+/// Then: listing does NOT reload (watch mode gate)
+#[test]
+fn poll_dir_changed_noop_when_watch_off() {
+    let tmp = std::env::temp_dir().join(format!("trek_watch_noop_{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&tmp);
+    let mut app = make_app_at(&tmp);
+    // Don't enable watch mode — force a stale mtime anyway
+    app.last_dir_mtime = Some(std::time::SystemTime::UNIX_EPOCH);
+    std::fs::write(tmp.join("ignored.txt"), b"x").unwrap();
+    let before = app.entries.len();
+    app.poll_dir_changed();
+    assert_eq!(
+        app.entries.len(),
+        before,
+        "should not reload when watch mode is off"
+    );
+    let _ = std::fs::remove_dir_all(&tmp);
+}

--- a/src/args.rs
+++ b/src/args.rs
@@ -88,6 +88,7 @@ pub fn print_help() {
     println!("    d           Toggle diff preview R           Refresh git status");
     println!("    V           Toggle git log preview (file/dir commit history)");
     println!("    D           Toggle disk usage breakdown for selected directory");
+    println!("    I           Watch mode — auto-refresh listing on filesystem changes");
     println!("    f           Compare two selected files (unified diff)");
     println!("    H           Toggle hash preview (SHA-256 checksum)");
     println!("    a           Toggle hex dump view (binary file inspection)");

--- a/src/events.rs
+++ b/src/events.rs
@@ -11,6 +11,7 @@ use crossterm::{
 use ratatui::{backend::CrosstermBackend, Terminal};
 use std::io;
 use std::path::PathBuf;
+use std::time::Duration;
 
 /// Install a panic hook that restores the terminal before the default hook
 /// prints the panic message.  This ensures the terminal is usable after a
@@ -41,7 +42,21 @@ pub fn run(
     loop {
         terminal.draw(|f| crate::ui::draw(f, &mut app))?;
 
-        match event::read()? {
+        // When watch mode is active, poll with a 500 ms timeout so the loop
+        // can detect directory changes even when the user is idle.
+        let maybe_event = if app.watch_mode {
+            if event::poll(Duration::from_millis(500))? {
+                Some(event::read()?)
+            } else {
+                app.poll_dir_changed();
+                None
+            }
+        } else {
+            Some(event::read()?)
+        };
+        let Some(ev) = maybe_event else { continue };
+
+        match ev {
             Event::Key(key) => {
                 // Clear status message on any keypress.
                 app.clear_status();
@@ -298,6 +313,7 @@ pub fn run(
                         KeyCode::Char('H') => app.toggle_hash_preview(),
                         KeyCode::Char('V') => app.toggle_git_log_preview(),
                         KeyCode::Char('D') => app.toggle_du_preview(),
+                        KeyCode::Char('I') => app.toggle_watch_mode(),
                         KeyCode::Char('f') => app.toggle_file_compare(),
                         KeyCode::Char('a') => app.toggle_hex_view(),
                         KeyCode::Char('w') => app.toggle_preview_pane(),
@@ -484,6 +500,7 @@ fn execute_palette_action(
         ActionId::ToggleHashPreview => app.toggle_hash_preview(),
         ActionId::ToggleGitLogPreview => app.toggle_git_log_preview(),
         ActionId::ToggleDuPreview => app.toggle_du_preview(),
+        ActionId::ToggleWatchMode => app.toggle_watch_mode(),
         ActionId::CompareFiles => app.toggle_file_compare(),
         ActionId::ToggleHexView => app.toggle_hex_view(),
         ActionId::TogglePreviewPane => app.toggle_preview_pane(),

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -280,6 +280,16 @@ fn draw_path_bar(f: &mut Frame, app: &App, area: Rect) {
         ));
     }
 
+    // Watch mode indicator.
+    if app.watch_mode {
+        spans.push(Span::styled(
+            "  [watch]",
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        ));
+    }
+
     f.render_widget(Paragraph::new(Line::from(spans)), area);
 }
 
@@ -1968,7 +1978,7 @@ fn draw_yank_picker(f: &mut Frame, app: &App, size: Rect) {
 
 fn draw_help_overlay(f: &mut Frame, size: Rect) {
     let width = 60u16.min(size.width.saturating_sub(4));
-    let height = 96u16.min(size.height.saturating_sub(4));
+    let height = 98u16.min(size.height.saturating_sub(4));
     let x = (size.width.saturating_sub(width)) / 2;
     let y = (size.height.saturating_sub(height)) / 2;
     let area = Rect::new(x, y, width, height);
@@ -2016,6 +2026,10 @@ fn draw_help_overlay(f: &mut Frame, size: Rect) {
         key_line("d", "Toggle git diff preview"),
         key_line("V", "Toggle git log preview (commit history)"),
         key_line("D", "Toggle disk usage breakdown for directory"),
+        key_line(
+            "I",
+            "Watch mode (auto-refresh listing on filesystem changes)",
+        ),
         key_line("f", "Compare two selected files (unified diff)"),
         key_line("m", "Toggle file metadata view"),
         key_line("H", "Toggle hash preview (SHA-256 checksum)"),


### PR DESCRIPTION
## Summary
- Press `I` to toggle watch mode; the event loop polls at 500 ms and re-runs `load_dir()` on directory mtime change
- Previously selected entry is restored by name after refresh so the cursor stays stable
- Path bar gains a cyan `[watch]` badge; status bar confirms ON/OFF

## Test plan
- [ ] `cargo test` passes (262 tests)
- [ ] Toggle `I` in a directory, create a file in another terminal — listing refreshes automatically
- [ ] Cursor stays on previously selected file after refresh
- [ ] `[watch]` badge appears in path bar when active
- [ ] Command palette shows `ToggleWatchMode` with `I` key
- [ ] `?` help overlay lists `I — Watch mode`

Closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)