### PR TITLE
feat(trek): archive creation from selected files — E key (#92)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.48.0] - 2026-03-24
+
+### Added
+- **`E` — create archive from selected files**: press `E` to open a filename input bar (pre-filled with `<entry>.tar.gz`) and type an archive name; Trek infers the format from the extension and runs the appropriate tool
+- Supports `.tar.gz` / `.tgz`, `.tar.bz2` / `.tbz2`, `.tar.xz` / `.txz`, `.tar.zst` / `.tzst`, `.tar`, and `.zip`; `.gz` and `.7z` are unsupported for creation and show a clear error
+- `E` with no selection archives the current entry; with 1 selection it pre-fills `<name>.tar.gz`; with multiple selections it pre-fills `archive.tar.gz`
+- Created archive appears in the listing immediately with the cursor moved to it
+- Error cases handled gracefully: unknown extension, output already exists, `zip` binary not found
+- `BeginArchiveCreate` registered in command palette (`E`) and `?` help overlay
+- `Z` extracts; `E` creates — they are a symmetric pair
+
 ## [0.47.0] - 2026-03-24
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -586,7 +586,7 @@ dependencies = [
 
 [[package]]
 name = "trek"
-version = "0.46.0"
+version = "0.47.0"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trek"
-version = "0.47.0"
+version = "0.48.0"
 edition = "2021"
 rust-version = "1.80"
 description = "A terminal file manager with mouse-resizable panes"

--- a/src/app/file_ops.rs
+++ b/src/app/file_ops.rs
@@ -557,4 +557,104 @@ impl App {
         self.pending_extract = None;
         self.status_message = Some("Extract cancelled".to_string());
     }
+
+    // ── Archive creation (E) ──────────────────────────────────────────────────
+
+    /// Open the archive-creation input bar with a suggested filename.
+    ///
+    /// - 1 entry selected → `"<name>.tar.gz"`
+    /// - Multiple selected → `"archive.tar.gz"`
+    /// - No selection → current entry name + `".tar.gz"`
+    pub fn begin_archive_create(&mut self) {
+        let suggestion = if !self.rename_selected.is_empty() {
+            if self.rename_selected.len() == 1 {
+                let idx = *self.rename_selected.iter().next().unwrap();
+                let stem = self
+                    .entries
+                    .get(idx)
+                    .map(|e| e.name.as_str())
+                    .unwrap_or("archive");
+                format!("{}.tar.gz", stem)
+            } else {
+                "archive.tar.gz".to_string()
+            }
+        } else if let Some(entry) = self.entries.get(self.selected) {
+            format!("{}.tar.gz", entry.name)
+        } else {
+            return; // No entries at all.
+        };
+        self.archive_create_input = suggestion;
+        self.archive_create_mode = true;
+    }
+
+    /// Cancel the archive-creation input bar without creating anything.
+    pub fn cancel_archive_create(&mut self) {
+        self.archive_create_mode = false;
+        self.archive_create_input.clear();
+        self.status_message = Some("Archive creation cancelled".to_string());
+    }
+
+    /// Validate the typed name and create the archive.
+    pub fn confirm_archive_create(&mut self) {
+        let name = self.archive_create_input.trim().to_string();
+        self.archive_create_mode = false;
+        self.archive_create_input.clear();
+
+        if name.is_empty() {
+            return;
+        }
+
+        let output_path = self.cwd.join(&name);
+        if output_path.exists() {
+            self.status_message = Some(format!("'{}' already exists", name));
+            return;
+        }
+
+        // Collect inputs: selected entries, or current entry if no selection.
+        let inputs: Vec<PathBuf> = if !self.rename_selected.is_empty() {
+            self.rename_selected
+                .iter()
+                .filter_map(|&i| self.entries.get(i).map(|e| e.path.clone()))
+                .collect()
+        } else {
+            self.entries
+                .get(self.selected)
+                .map(|e| vec![e.path.clone()])
+                .unwrap_or_default()
+        };
+
+        if inputs.is_empty() {
+            return;
+        }
+
+        let n = inputs.len();
+        match crate::archive::create_archive(&output_path, &inputs) {
+            Ok(()) => {
+                self.load_dir();
+                if let Some(idx) = self.entries.iter().position(|e| e.name == name) {
+                    self.selected = idx;
+                    self.load_preview();
+                }
+                self.status_message = Some(format!(
+                    "Created {} ({} entr{})",
+                    name,
+                    n,
+                    if n == 1 { "y" } else { "ies" }
+                ));
+            }
+            Err(msg) => {
+                self.status_message = Some(format!("Archive failed: {}", msg));
+            }
+        }
+    }
+
+    /// Append a character to the archive name input.
+    pub fn archive_create_push_char(&mut self, c: char) {
+        self.archive_create_input.push(c);
+    }
+
+    /// Remove the last character from the archive name input.
+    pub fn archive_create_pop_char(&mut self) {
+        self.archive_create_input.pop();
+    }
 }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -397,6 +397,12 @@ pub struct App {
     pub frecency_selected: usize,
     /// Current filter query typed in the overlay.
     pub frecency_query: String,
+
+    // --- Archive creation (E) ---
+    /// True while the archive-creation filename input bar is shown.
+    pub archive_create_mode: bool,
+    /// Filename being typed for the new archive.
+    pub archive_create_input: String,
 }
 
 #[derive(Clone)]
@@ -535,6 +541,8 @@ impl App {
             frecency_filtered: Vec::new(),
             frecency_selected: 0,
             frecency_query: String::new(),
+            archive_create_mode: false,
+            archive_create_input: String::new(),
         };
         app.load_dir();
         Ok(app)

--- a/src/app/palette.rs
+++ b/src/app/palette.rs
@@ -66,6 +66,7 @@ pub enum ActionId {
     ToggleHexView,
     InspectClipboard,
     OpenFrecency,
+    BeginArchiveCreate,
     ShowHelp,
     Quit,
 }
@@ -379,6 +380,11 @@ pub static PALETTE_ACTIONS: &[PaletteAction] = &[
         id: ActionId::OpenFrecency,
         name: "Open frecency jump list (auto-ranked recent dirs)",
         keys: "z",
+    },
+    PaletteAction {
+        id: ActionId::BeginArchiveCreate,
+        name: "Create archive from selected files (tar.gz, zip, …)",
+        keys: "E",
     },
     PaletteAction {
         id: ActionId::ShowHelp,

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -3555,6 +3555,141 @@ fn poll_dir_changed_detects_new_file() {
     let _ = std::fs::remove_dir_all(&tmp);
 }
 
+// ── Archive creation tests (issue #92) ───────────────────────────────────────
+
+/// Given: the app is in a directory with at least one entry and no selection
+/// When: begin_archive_create is called
+/// Then: archive_create_mode becomes true and input is pre-filled with "<entry>.tar.gz"
+#[test]
+fn begin_archive_create_no_selection_prefills_entry_name() {
+    let tmp = std::env::temp_dir().join(format!("trek_arc_begin_{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&tmp);
+    std::fs::write(tmp.join("main.rs"), b"fn main(){}").unwrap();
+    let mut app = make_app_at(&tmp);
+    assert!(!app.archive_create_mode);
+    app.begin_archive_create();
+    assert!(app.archive_create_mode);
+    assert_eq!(app.archive_create_input, "main.rs.tar.gz");
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+/// Given: exactly one entry is selected
+/// When: begin_archive_create is called
+/// Then: input is pre-filled with "<selected_entry>.tar.gz"
+#[test]
+fn begin_archive_create_single_selection_prefills_name() {
+    let tmp = std::env::temp_dir().join(format!("trek_arc_single_{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&tmp);
+    std::fs::write(tmp.join("lib.rs"), b"").unwrap();
+    let mut app = make_app_at(&tmp);
+    app.rename_selected.insert(0);
+    app.begin_archive_create();
+    assert!(app.archive_create_mode);
+    assert_eq!(app.archive_create_input, "lib.rs.tar.gz");
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+/// Given: more than one entry is selected
+/// When: begin_archive_create is called
+/// Then: input is pre-filled with "archive.tar.gz"
+#[test]
+fn begin_archive_create_multi_selection_prefills_archive() {
+    let tmp = std::env::temp_dir().join(format!("trek_arc_multi_{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&tmp);
+    std::fs::write(tmp.join("a.rs"), b"").unwrap();
+    std::fs::write(tmp.join("b.rs"), b"").unwrap();
+    let mut app = make_app_at(&tmp);
+    app.rename_selected.insert(0);
+    app.rename_selected.insert(1);
+    app.begin_archive_create();
+    assert!(app.archive_create_mode);
+    assert_eq!(app.archive_create_input, "archive.tar.gz");
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+/// Given: archive_create_mode is true with some input
+/// When: cancel_archive_create is called
+/// Then: mode becomes false and input is cleared
+#[test]
+fn cancel_archive_create_clears_mode_and_input() {
+    let tmp = std::env::temp_dir().join(format!("trek_arc_cancel_{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&tmp);
+    std::fs::write(tmp.join("f.txt"), b"x").unwrap();
+    let mut app = make_app_at(&tmp);
+    app.begin_archive_create();
+    assert!(app.archive_create_mode);
+    app.cancel_archive_create();
+    assert!(!app.archive_create_mode);
+    assert!(app.archive_create_input.is_empty());
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+/// Given: an archive name that already exists in the cwd
+/// When: confirm_archive_create is called
+/// Then: an "already exists" error is shown and no archive is created
+#[test]
+fn confirm_archive_create_existing_name_shows_error() {
+    let tmp = std::env::temp_dir().join(format!("trek_arc_exists_{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&tmp);
+    std::fs::write(tmp.join("f.txt"), b"hi").unwrap();
+    std::fs::write(tmp.join("out.tar.gz"), b"").unwrap(); // pre-existing archive
+    let mut app = make_app_at(&tmp);
+    app.archive_create_mode = true;
+    app.archive_create_input = "out.tar.gz".to_string();
+    app.confirm_archive_create();
+    let msg = app.status_message.clone().unwrap_or_default();
+    assert!(
+        msg.contains("already exists"),
+        "expected 'already exists', got: {msg}"
+    );
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+/// Given: an unknown archive extension (e.g. .bak) is typed
+/// When: confirm_archive_create is called
+/// Then: an "Unknown archive format" error is shown
+#[test]
+fn confirm_archive_create_unknown_ext_shows_error() {
+    let tmp = std::env::temp_dir().join(format!("trek_arc_badext_{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&tmp);
+    std::fs::write(tmp.join("f.txt"), b"hi").unwrap();
+    let mut app = make_app_at(&tmp);
+    app.archive_create_mode = true;
+    app.archive_create_input = "backup.bak".to_string();
+    app.confirm_archive_create();
+    let msg = app.status_message.clone().unwrap_or_default();
+    assert!(
+        msg.to_lowercase().contains("unknown archive format")
+            || msg.to_lowercase().contains("archive failed"),
+        "expected unknown format error, got: {msg}"
+    );
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+/// Given: a valid .tar.gz name and a real file to archive
+/// When: confirm_archive_create is called
+/// Then: the archive file is created on disk and the status message contains the archive name
+#[test]
+fn confirm_archive_create_tar_gz_creates_file() {
+    let tmp = std::env::temp_dir().join(format!("trek_arc_create_{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&tmp);
+    std::fs::write(tmp.join("hello.txt"), b"hello world").unwrap();
+    let mut app = make_app_at(&tmp);
+    app.archive_create_mode = true;
+    app.archive_create_input = "out.tar.gz".to_string();
+    app.confirm_archive_create();
+    assert!(
+        tmp.join("out.tar.gz").exists(),
+        "archive should be created on disk"
+    );
+    let msg = app.status_message.clone().unwrap_or_default();
+    assert!(
+        msg.contains("out.tar.gz"),
+        "status should reference archive name, got: {msg}"
+    );
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
 /// Given: watch mode is off
 /// When: poll_dir_changed is called even with a changed mtime
 /// Then: listing does NOT reload (watch mode gate)

--- a/src/archive.rs
+++ b/src/archive.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 pub const MAX_ARCHIVE_ENTRIES: usize = 1_000;
@@ -156,6 +156,61 @@ fn truncate_if_needed(mut lines: Vec<String>) -> Vec<String> {
 /// Returns `true` if `path` has a recognized archive extension.
 pub fn is_archive(path: &Path) -> bool {
     archive_ext(path).is_some()
+}
+
+/// Create an archive at `output_path` containing all paths in `inputs`.
+///
+/// Returns `Ok(())` on success or `Err(human-readable message)` on failure.
+/// Callers must verify the output path does not already exist before calling.
+pub fn create_archive(output_path: &Path, inputs: &[PathBuf]) -> Result<(), String> {
+    let ext = archive_ext(output_path).ok_or_else(|| {
+        "Unknown archive format; use .tar.gz, .tar.bz2, .tar.xz, .zip, or .tar".to_string()
+    })?;
+
+    let out_str = output_path
+        .to_str()
+        .ok_or_else(|| "Archive path contains invalid UTF-8".to_string())?
+        .to_owned();
+
+    let input_strs: Vec<String> = inputs
+        .iter()
+        .filter_map(|p| p.to_str().map(|s| s.to_owned()))
+        .collect();
+
+    match ext {
+        ArchiveExt::Tar => run_create("tar", &["-cf", &out_str], &input_strs),
+        ArchiveExt::TarGz => run_create("tar", &["-czf", &out_str], &input_strs),
+        ArchiveExt::TarBz2 => run_create("tar", &["-cjf", &out_str], &input_strs),
+        ArchiveExt::TarXz => run_create("tar", &["-cJf", &out_str], &input_strs),
+        ArchiveExt::TarZst => run_create("tar", &["--zstd", "-cf", &out_str], &input_strs),
+        ArchiveExt::Zip => {
+            if !command_exists("zip") {
+                return Err(
+                    "zip not found — install: brew install zip (macOS) / apt install zip (Linux)"
+                        .to_string(),
+                );
+            }
+            run_create("zip", &["-r", &out_str], &input_strs)
+        }
+        ArchiveExt::Gz | ArchiveExt::SevenZip => {
+            Err("Unknown archive format; use .tar.gz, .tar.bz2, .tar.xz, .zip, or .tar".to_string())
+        }
+    }
+}
+
+/// Run `bin args... inputs...` and return `Ok(())` or `Err(stderr)`.
+fn run_create(bin: &str, args: &[&str], inputs: &[String]) -> Result<(), String> {
+    let input_refs: Vec<&str> = inputs.iter().map(|s| s.as_str()).collect();
+    let out = Command::new(bin)
+        .args(args)
+        .args(&input_refs)
+        .output()
+        .map_err(|e| format!("Failed to run {}: {}", bin, e))?;
+    if out.status.success() {
+        Ok(())
+    } else {
+        Err(String::from_utf8_lossy(&out.stderr).trim().to_string())
+    }
 }
 
 /// Extract the archive at `path` into `dest_dir`.

--- a/src/args.rs
+++ b/src/args.rs
@@ -109,6 +109,7 @@ pub fn print_help() {
     println!("    L           Create symlink to selected entry (Unix only)");
     println!("    W           Duplicate selected entry in place (editable name bar)");
     println!("    Z           Extract archive to current directory");
+    println!("    E           Create archive from selected files (tar.gz, zip, …)");
     println!("    X           Delete all selected");
     println!("    :           Open command palette");
     println!("    ?           Show help overlay  q           Quit");

--- a/src/events.rs
+++ b/src/events.rs
@@ -80,6 +80,14 @@ pub fn run(
                         }
                         _ => app.cancel_extract(),
                     }
+                } else if app.archive_create_mode {
+                    match key.code {
+                        KeyCode::Esc => app.cancel_archive_create(),
+                        KeyCode::Enter => app.confirm_archive_create(),
+                        KeyCode::Backspace => app.archive_create_pop_char(),
+                        KeyCode::Char(c) => app.archive_create_push_char(c),
+                        _ => {}
+                    }
                 } else if app.mkdir_mode {
                     match key.code {
                         KeyCode::Esc => app.cancel_mkdir(),
@@ -350,6 +358,7 @@ pub fn run(
                         KeyCode::Char('W') => app.begin_dup(),
                         KeyCode::Char('L') => app.begin_symlink(),
                         KeyCode::Char('Z') => app.begin_extract(),
+                        KeyCode::Char('E') => app.begin_archive_create(),
                         // Quick single-file rename
                         KeyCode::Char('n') | KeyCode::F(2) => app.begin_quick_rename(),
                         KeyCode::Char('u') => app.undo_trash(),
@@ -547,6 +556,7 @@ fn execute_palette_action(
         ActionId::BeginDup => app.begin_dup(),
         ActionId::BeginSymlink => app.begin_symlink(),
         ActionId::BeginExtract => app.begin_extract(),
+        ActionId::BeginArchiveCreate => app.begin_archive_create(),
         ActionId::InspectClipboard => app.open_clipboard_inspect(),
         ActionId::OpenFrecency => app.open_frecency(),
         ActionId::ShowHelp => app.show_help = true,

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -101,6 +101,8 @@ pub fn draw(f: &mut Frame, app: &mut App) {
         draw_delete_confirm_bar(f, app, bottom_area);
     } else if let Some(ref path) = app.pending_extract {
         draw_extract_bar(f, bottom_area, path);
+    } else if app.archive_create_mode {
+        draw_archive_create_bar(f, app, bottom_area);
     } else if app.quick_rename_mode {
         draw_quick_rename_bar(f, app, bottom_area);
     } else if app.path_mode {
@@ -513,6 +515,29 @@ fn draw_touch_bar(f: &mut Frame, app: &App, area: Rect) {
         ),
         Span::styled(
             &app.touch_input,
+            Style::default()
+                .fg(Color::White)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled("\u{2588}", Style::default().fg(Color::White)),
+        Span::styled(
+            "  Enter: create   Esc: cancel",
+            Style::default().fg(Color::DarkGray),
+        ),
+    ]));
+    f.render_widget(para, area);
+}
+
+fn draw_archive_create_bar(f: &mut Frame, app: &App, area: Rect) {
+    let para = Paragraph::new(Line::from(vec![
+        Span::styled(
+            "Archive:  ",
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(
+            &app.archive_create_input,
             Style::default()
                 .fg(Color::White)
                 .add_modifier(Modifier::BOLD),
@@ -1978,7 +2003,7 @@ fn draw_yank_picker(f: &mut Frame, app: &App, size: Rect) {
 
 fn draw_help_overlay(f: &mut Frame, size: Rect) {
     let width = 60u16.min(size.width.saturating_sub(4));
-    let height = 98u16.min(size.height.saturating_sub(4));
+    let height = 100u16.min(size.height.saturating_sub(4));
     let x = (size.width.saturating_sub(width)) / 2;
     let y = (size.height.saturating_sub(height)) / 2;
     let area = Rect::new(x, y, width, height);
@@ -2067,6 +2092,7 @@ fn draw_help_overlay(f: &mut Frame, size: Rect) {
         key_line("W", "Duplicate selected entry in place"),
         key_line("L", "Create symlink to selected entry"),
         key_line("Z", "Extract archive to current directory"),
+        key_line("E", "Create archive from selected files (tar.gz, zip, …)"),
         key_line("M", "Make new directory"),
         Line::from(""),
         // ── Yank & Misc ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Press `E` to open a filename input bar; Trek infers format from extension and runs `tar` or `zip`
- Supports `.tar.gz`, `.tar.bz2`, `.tar.xz`, `.tar.zst`, `.tar`, `.zip`
- `Z` extracts; `E` creates — symmetric pair; cursor moves to created archive

## Test plan
- [ ] `cargo test` passes (269 tests)
- [ ] `E` with no selection pre-fills `<entry>.tar.gz`; Enter creates the archive
- [ ] `E` with 1 selected entry pre-fills `<name>.tar.gz`
- [ ] `E` with N selected entries pre-fills `archive.tar.gz`
- [ ] Unknown extension (`.bak`) shows "Unknown archive format" error
- [ ] Name that already exists shows "already exists" error
- [ ] Created archive appears in listing with cursor on it
- [ ] Esc cancels without creating anything
- [ ] Command palette shows `BeginArchiveCreate` with `E` key
- [ ] `?` help overlay lists `E — Create archive from selected files`

Closes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)