### PR TITLE
feat(nav): always-on filesystem watcher (auto-refresh)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.51.0] - 2026-03-24
+
+### Added
+- **Always-on filesystem watcher**: Trek now automatically watches the current directory for changes using OS-native events (FSEvents on macOS, inotify on Linux) via the `notify` crate — no keypress required
+- The listing refreshes automatically within ~150 ms of any file creation, deletion, rename, or modification in the current directory
+- `I` still toggles the watcher off/on for users who prefer manual refresh; the `[watch]` badge in the path bar reflects the active state
+- Watcher updates automatically when navigating to a new directory
+- Graceful degradation: if the OS watcher fails to start (e.g. inotify limit, read-only filesystem), Trek continues working exactly as before with manual `R` refresh
+- Debounce window of 150 ms coalesces rapid bursts (e.g. `git checkout` touching many files) into a single reload
+
+### Changed
+- Watch mode is now **on by default** — previously required pressing `I` to activate
+- The event loop polls with a 150 ms timeout (down from 500 ms) when the watcher is active, driven by OS events rather than mtime polling
+
 ## [0.50.0] - 2026-03-24
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,6 +61,12 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
@@ -109,12 +115,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "crossterm"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "crossterm_winapi",
  "libc",
  "mio",
@@ -167,6 +188,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+]
+
+[[package]]
 name = "flate2"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -189,6 +221,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -204,6 +245,26 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "inotify"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
+dependencies = [
+ "bitflags 1.3.2",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "itertools"
@@ -230,10 +291,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "kqueue"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+
+[[package]]
+name = "libredox"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
+dependencies = [
+ "bitflags 2.11.0",
+ "libc",
+ "plain",
+ "redox_syscall 0.7.3",
+]
 
 [[package]]
 name = "lock_api"
@@ -288,6 +381,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "notify"
+version = "6.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
+dependencies = [
+ "bitflags 2.11.0",
+ "crossbeam-channel",
+ "filetime",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "walkdir",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "notify-debouncer-mini"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d40b221972a1fc5ef4d858a2f671fb34c75983eb385463dff3780eeff6a9d43"
+dependencies = [
+ "crossbeam-channel",
+ "log",
+ "notify",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -311,7 +434,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
 ]
@@ -321,6 +444,12 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "proc-macro2"
@@ -346,7 +475,7 @@ version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f44c9e68fd46eda15c646fbb85e1040b657a58cdc8c98db1d97a55930d991eef"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "cassowary",
  "compact_str",
  "crossterm",
@@ -366,7 +495,16 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
+dependencies = [
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -591,6 +729,8 @@ dependencies = [
  "anyhow",
  "base64",
  "crossterm",
+ "notify",
+ "notify-debouncer-mini",
  "ratatui",
  "regex",
  "syntect",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trek"
-version = "0.50.0"
+version = "0.51.0"
 edition = "2021"
 rust-version = "1.80"
 description = "A terminal file manager with mouse-resizable panes"
@@ -15,3 +15,5 @@ anyhow = "1"
 base64 = "0.22"
 regex = "1"
 syntect = { version = "5", default-features = false, features = ["default-syntaxes", "default-themes", "regex-fancy"] }
+notify = "6"
+notify-debouncer-mini = "0.4"

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -192,11 +192,11 @@ pub struct App {
     /// When true the preview pane shows a `du -k -d 1` breakdown of the selected directory.
     pub du_preview_mode: bool,
 
-    // --- Watch mode (I) ---
-    /// When true the event loop polls for directory changes every 500 ms.
-    pub watch_mode: bool,
-    /// Mtime of `cwd` at last load; used to detect changes in watch mode.
-    pub last_dir_mtime: Option<std::time::SystemTime>,
+    // --- Filesystem watcher (auto-refresh, always-on by default; I toggles off/on) ---
+    /// OS-native directory watcher. Some when watching is active, None when
+    /// the user has disabled auto-refresh with `I`. Trek starts watching
+    /// automatically — no keypress required.
+    pub watcher: Option<crate::watcher::DirWatcher>,
 
     // --- chmod editor (P) ---
     /// True while the chmod input bar is open.
@@ -463,8 +463,7 @@ impl App {
             file_compare_mode: false,
             hex_view_mode: false,
             du_preview_mode: false,
-            watch_mode: false,
-            last_dir_mtime: None,
+            watcher: crate::watcher::DirWatcher::new(&cwd),
             chmod_mode: false,
             chmod_input: String::new(),
             highlighter: Highlighter::new(),
@@ -609,9 +608,10 @@ impl App {
         self.git_status = GitStatus::load(&self.cwd);
         self.diff_preview_mode = false;
 
-        // Keep mtime baseline current so watch mode detects the *next* change.
-        if self.watch_mode {
-            self.last_dir_mtime = std::fs::metadata(&self.cwd).and_then(|m| m.modified()).ok();
+        // Replace the watcher so it tracks the current directory.
+        // Only recreate it when watching is active (watcher is Some).
+        if self.watcher.is_some() {
+            self.watcher = crate::watcher::DirWatcher::new(&self.cwd);
         }
 
         self.load_preview();

--- a/src/app/navigation.rs
+++ b/src/app/navigation.rs
@@ -653,37 +653,42 @@ impl App {
         }
     }
 
-    // --- Watch mode (I) ---
+    // --- Filesystem watcher (I toggles off/on) ---
 
-    /// Toggle watch mode (auto-refresh listing on directory mtime change).
+    /// Toggle the filesystem watcher off or on.
+    ///
+    /// The watcher starts automatically on launch; `I` lets users opt out.
+    /// Toggling back on restarts the watcher for the current directory.
     pub fn toggle_watch_mode(&mut self) {
-        self.watch_mode = !self.watch_mode;
-        if self.watch_mode {
-            self.last_dir_mtime = std::fs::metadata(&self.cwd).and_then(|m| m.modified()).ok();
+        if self.watcher.is_some() {
+            // Turn off — drop the watcher (cancels the OS watch automatically).
+            self.watcher = None;
+            self.status_message = Some("Watch mode OFF".to_string());
+        } else {
+            // Turn on — start a fresh watcher for the current directory.
+            self.watcher = crate::watcher::DirWatcher::new(&self.cwd);
             self.status_message =
                 Some("Watch mode ON — listing auto-refreshes on changes".to_string());
-        } else {
-            self.last_dir_mtime = None;
-            self.status_message = Some("Watch mode OFF".to_string());
         }
     }
 
-    /// Check whether the current directory has been modified since the last
-    /// load. Called on each poll timeout when watch mode is active.
+    /// Drain any pending filesystem events and reload the listing if changes
+    /// were detected. Called in the event loop via a non-blocking `try_recv`.
     ///
-    /// Reloads the listing if the mtime changed, preserving the selection by name.
-    pub fn poll_dir_changed(&mut self) {
-        if !self.watch_mode {
-            return;
-        }
-        let current_mtime = std::fs::metadata(&self.cwd).and_then(|m| m.modified()).ok();
-        let changed = match (current_mtime, self.last_dir_mtime) {
-            (Some(current), Some(last)) => current != last,
-            _ => false,
+    /// Preserves the current selection by name across the reload.
+    pub fn check_watcher(&mut self) {
+        let has_events = if let Some(ref w) = self.watcher {
+            // Drain all pending events; the debouncer already coalesced bursts.
+            let mut got_event = false;
+            while w.rx.try_recv().is_ok() {
+                got_event = true;
+            }
+            got_event
+        } else {
+            false
         };
-        if changed {
-            // Update baseline before load_dir() to avoid re-trigger.
-            self.last_dir_mtime = current_mtime;
+
+        if has_events {
             let selected_name = self.entries.get(self.selected).map(|e| e.name.clone());
             self.load_dir();
             if let Some(name) = selected_name {
@@ -692,6 +697,7 @@ impl App {
                     self.load_preview();
                 }
             }
+            self.status_message = Some("Refreshed".to_string());
         }
     }
 }

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -3606,17 +3606,25 @@ fn toggle_meta_clears_du_preview_mode() {
     let _ = std::fs::remove_dir_all(&tmp);
 }
 
-/// Given: watch mode is off
-/// When: toggle_watch_mode is called
-/// Then: watch_mode becomes true and status_message mentions ON
+/// Given: the watcher is active (default on)
+/// When: toggle_watch_mode is called once (turn off) then again (turn on)
+/// Then: first call produces OFF message, second produces ON message
 #[test]
-fn toggle_watch_mode_turns_on() {
-    let tmp = std::env::temp_dir().join(format!("trek_watch_on_{}", std::process::id()));
+fn toggle_watch_mode_turns_off_then_on() {
+    let tmp = std::env::temp_dir().join(format!("trek_watch_toggle_{}", std::process::id()));
     let _ = std::fs::create_dir_all(&tmp);
     let mut app = make_app_at(&tmp);
-    assert!(!app.watch_mode);
-    app.toggle_watch_mode();
-    assert!(app.watch_mode);
+    // Watcher is active by default.
+    assert!(app.watcher.is_some());
+    app.toggle_watch_mode(); // turn off
+    assert!(app.watcher.is_none());
+    let msg = app.status_message.clone().unwrap_or_default();
+    assert!(
+        msg.to_lowercase().contains("off"),
+        "expected OFF message: {msg}"
+    );
+    app.toggle_watch_mode(); // turn back on
+    assert!(app.watcher.is_some());
     let msg = app.status_message.clone().unwrap_or_default();
     assert!(
         msg.to_lowercase().contains("on"),
@@ -3625,18 +3633,37 @@ fn toggle_watch_mode_turns_on() {
     let _ = std::fs::remove_dir_all(&tmp);
 }
 
-/// Given: watch mode is on
-/// When: toggle_watch_mode is called
-/// Then: watch_mode becomes false and status_message mentions OFF
+// ── Filesystem watcher tests (issue #33) ─────────────────────────────────────
+
+/// Given: a valid directory
+/// When: App::new is called
+/// Then: the watcher is automatically started (watcher is Some)
 #[test]
-fn toggle_watch_mode_turns_off() {
-    let tmp = std::env::temp_dir().join(format!("trek_watch_off_{}", std::process::id()));
+fn app_new_starts_watcher_automatically() {
+    let tmp = std::env::temp_dir().join(format!("trek_watcher_auto_{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&tmp);
+    let app = make_app_at(&tmp);
+    assert!(
+        app.watcher.is_some(),
+        "watcher should start automatically on app creation"
+    );
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+/// Given: the app has an active watcher
+/// When: toggle_watch_mode is called (turns it off)
+/// Then: watcher becomes None and status message mentions OFF
+#[test]
+fn toggle_watch_mode_off_drops_watcher() {
+    let tmp = std::env::temp_dir().join(format!("trek_watcher_off_{}", std::process::id()));
     let _ = std::fs::create_dir_all(&tmp);
     let mut app = make_app_at(&tmp);
+    assert!(app.watcher.is_some());
     app.toggle_watch_mode();
-    assert!(app.watch_mode);
-    app.toggle_watch_mode();
-    assert!(!app.watch_mode);
+    assert!(
+        app.watcher.is_none(),
+        "watcher should be None after toggling off"
+    );
     let msg = app.status_message.clone().unwrap_or_default();
     assert!(
         msg.to_lowercase().contains("off"),
@@ -3645,24 +3672,44 @@ fn toggle_watch_mode_turns_off() {
     let _ = std::fs::remove_dir_all(&tmp);
 }
 
-/// Given: watch mode is on and a new file appears in the directory
-/// When: poll_dir_changed is called
-/// Then: the new file appears in the listing
+/// Given: the watcher is disabled
+/// When: toggle_watch_mode is called again
+/// Then: watcher is recreated (Some) and status message mentions ON
 #[test]
-fn poll_dir_changed_detects_new_file() {
-    let tmp = std::env::temp_dir().join(format!("trek_watch_poll_{}", std::process::id()));
+fn toggle_watch_mode_on_restarts_watcher() {
+    let tmp = std::env::temp_dir().join(format!("trek_watcher_on_{}", std::process::id()));
     let _ = std::fs::create_dir_all(&tmp);
     let mut app = make_app_at(&tmp);
-    app.toggle_watch_mode(); // ON — records initial mtime
-                             // Force mtime to appear changed by backdating last_dir_mtime
-    app.last_dir_mtime = Some(std::time::SystemTime::UNIX_EPOCH);
-    // Create a new file — listing is stale
-    std::fs::write(tmp.join("newfile.txt"), b"x").unwrap();
-    let before = app.entries.len();
-    app.poll_dir_changed();
+    app.toggle_watch_mode(); // turn off
+    assert!(app.watcher.is_none());
+    app.toggle_watch_mode(); // turn on
     assert!(
-        app.entries.len() > before,
-        "new file should appear after poll"
+        app.watcher.is_some(),
+        "watcher should be recreated after toggling on"
+    );
+    let msg = app.status_message.clone().unwrap_or_default();
+    assert!(
+        msg.to_lowercase().contains("on"),
+        "expected ON message: {msg}"
+    );
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+/// Given: the app navigates to a new directory
+/// When: load_dir is called
+/// Then: the watcher is updated to watch the new directory
+#[test]
+fn load_dir_updates_watcher_to_new_directory() {
+    let tmp = std::env::temp_dir().join(format!("trek_watcher_dir_{}", std::process::id()));
+    let sub = tmp.join("subdir");
+    let _ = std::fs::create_dir_all(&sub);
+    let mut app = make_app_at(&tmp);
+    assert!(app.watcher.is_some(), "watcher should be active initially");
+    app.cwd = sub.clone();
+    app.load_dir();
+    assert!(
+        app.watcher.is_some(),
+        "watcher should remain active after load_dir"
     );
     let _ = std::fs::remove_dir_all(&tmp);
 }
@@ -3802,23 +3849,23 @@ fn confirm_archive_create_tar_gz_creates_file() {
     let _ = std::fs::remove_dir_all(&tmp);
 }
 
-/// Given: watch mode is off
-/// When: poll_dir_changed is called even with a changed mtime
-/// Then: listing does NOT reload (watch mode gate)
+/// Given: the watcher is disabled (user toggled off)
+/// When: check_watcher is called
+/// Then: listing does NOT reload (no channel to poll)
 #[test]
-fn poll_dir_changed_noop_when_watch_off() {
+fn check_watcher_noop_when_watcher_disabled() {
     let tmp = std::env::temp_dir().join(format!("trek_watch_noop_{}", std::process::id()));
     let _ = std::fs::create_dir_all(&tmp);
     let mut app = make_app_at(&tmp);
-    // Don't enable watch mode — force a stale mtime anyway
-    app.last_dir_mtime = Some(std::time::SystemTime::UNIX_EPOCH);
+    app.toggle_watch_mode(); // disable
+    assert!(app.watcher.is_none());
     std::fs::write(tmp.join("ignored.txt"), b"x").unwrap();
     let before = app.entries.len();
-    app.poll_dir_changed();
+    app.check_watcher();
     assert_eq!(
         app.entries.len(),
         before,
-        "should not reload when watch mode is off"
+        "should not reload when watcher is disabled"
     );
     let _ = std::fs::remove_dir_all(&tmp);
 }

--- a/src/events.rs
+++ b/src/events.rs
@@ -55,13 +55,15 @@ pub fn run(
     loop {
         terminal.draw(|f| crate::ui::draw(f, &mut app))?;
 
-        // When watch mode is active, poll with a 500 ms timeout so the loop
-        // can detect directory changes even when the user is idle.
-        let maybe_event = if app.watch_mode {
-            if event::poll(Duration::from_millis(500))? {
+        // When the filesystem watcher is active, poll with a short timeout so
+        // the loop can process OS-native directory events even when idle.
+        // try_recv() is non-blocking — zero cost on the hot path when nothing
+        // has changed.
+        let maybe_event = if app.watcher.is_some() {
+            if event::poll(Duration::from_millis(150))? {
                 Some(event::read()?)
             } else {
-                app.poll_dir_changed();
+                app.check_watcher();
                 None
             }
         } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ mod session;
 mod shell;
 mod trash;
 mod ui;
+mod watcher;
 
 use anyhow::Result;
 use crossterm::{

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -282,8 +282,8 @@ fn draw_path_bar(f: &mut Frame, app: &App, area: Rect) {
         ));
     }
 
-    // Watch mode indicator.
-    if app.watch_mode {
+    // Watcher indicator — shown when the filesystem watcher is active.
+    if app.watcher.is_some() {
         spans.push(Span::styled(
             "  [watch]",
             Style::default()

--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -1,0 +1,54 @@
+//! Filesystem watcher for auto-refreshing the directory listing.
+//!
+//! Wraps `notify-debouncer-mini` to provide OS-native filesystem events
+//! (FSEvents on macOS, inotify on Linux) with a 150 ms debounce window.
+//!
+//! The watcher is always-on — Trek starts watching the current directory
+//! automatically and updates the watch target whenever the directory changes.
+//! Users can toggle it off/on with `I` if they prefer manual refresh.
+
+use notify_debouncer_mini::{new_debouncer, DebouncedEvent};
+use std::path::Path;
+use std::sync::mpsc::{self, Receiver};
+use std::time::Duration;
+
+/// Watches a single directory for filesystem changes.
+///
+/// The `rx` channel receives debounced event batches. Poll `rx.try_recv()`
+/// in the event loop — it is non-blocking and returns immediately when no
+/// events are pending.
+///
+/// Dropping this struct cancels the watch automatically.
+pub struct DirWatcher {
+    /// Receive end of the debounced event channel.
+    pub rx: Receiver<Vec<DebouncedEvent>>,
+    // Keep the debouncer alive; dropping it cancels the underlying OS watch.
+    _debouncer: notify_debouncer_mini::Debouncer<notify::RecommendedWatcher>,
+}
+
+impl DirWatcher {
+    /// Start watching `dir` for changes.
+    ///
+    /// Returns `None` if the OS watcher fails to initialise (e.g. inotify
+    /// limit reached, read-only filesystem). Trek degrades gracefully to
+    /// manual refresh (`R`) when this happens.
+    pub fn new(dir: &Path) -> Option<Self> {
+        let (tx, rx) = mpsc::channel();
+        let mut debouncer = new_debouncer(Duration::from_millis(150), move |res| {
+            if let Ok(events) = res {
+                let _ = tx.send(events);
+            }
+        })
+        .ok()?;
+
+        debouncer
+            .watcher()
+            .watch(dir, notify::RecursiveMode::NonRecursive)
+            .ok()?;
+
+        Some(DirWatcher {
+            rx,
+            _debouncer: debouncer,
+        })
+    }
+}


### PR DESCRIPTION
## Summary

- Replaces mtime polling (toggle-only, 500 ms) with OS-native filesystem events via the `notify` crate (FSEvents on macOS, inotify on Linux)
- The watcher starts automatically on launch — no keypress required
- The listing refreshes within ~150 ms of any file creation, deletion, rename, or modification
- Rapid bursts (e.g. `git checkout`) are coalesced into a single reload via a 150 ms debounce window
- `I` still lets users opt out; the `[watch]` badge in the path bar reflects watcher state
- Graceful degradation: if the OS watcher fails to start, Trek continues with manual `R` refresh

Closes #33

## Files changed

| File | Change |
|---|---|
| `Cargo.toml` | Add `notify` + `notify-debouncer-mini` |
| `src/watcher.rs` | New — `DirWatcher` struct wrapping `notify-debouncer-mini` |
| `src/main.rs` | Add `mod watcher;` |
| `src/app/mod.rs` | Replace `watch_mode: bool` + `last_dir_mtime` with `watcher: Option<DirWatcher>`; initialize automatically |
| `src/app/navigation.rs` | Rewrite `toggle_watch_mode()` to manage `DirWatcher`; add `check_watcher()` replacing `poll_dir_changed()` |
| `src/events.rs` | Poll watcher channel at 150 ms timeout instead of 500 ms mtime polling |
| `src/ui.rs` | Update `[watch]` badge to check `watcher.is_some()` |
| `src/app/tests.rs` | Update old tests; add 4 new Given/When/Then tests |
| `CHANGELOG.md` | Add `[0.51.0]` entry |

## Test plan

- [x] `cargo test` — 281 tests pass
- [x] `cargo clippy -- -D warnings` — zero warnings
- [x] `cargo build --release` — clean build
- [x] `cargo fmt` — applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)