### PR TITLE
feat(opener): rifle-style user-configurable file opener rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.54.0] - 2026-03-24
+
+### Added
+- **Rifle-style configurable file opener** — Trek now reads `~/.config/trek/opener.conf` (or `$XDG_CONFIG_HOME/trek/opener.conf`) and evaluates rules top-to-bottom; the first match wins. Rules use `ext <ext1|ext2>` or `glob <pattern>` matchers with a `{}` path placeholder in the command. Example: `ext md : cmux open --md {}`.
+- Built-in defaults ship as the fallback when no config file is present, preserving existing routing behaviour (system open for HTML/images/PDFs, `$EDITOR` in a new cmux surface for code/text).
+- User-configured commands are executed via `sh -c`, allowing full shell syntax and environment variable expansion.
+
 ## [0.53.0] - 2026-03-24
 
 ### Removed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "trek"
-version = "0.53.0"
+version = "0.54.0"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trek"
-version = "0.53.0"
+version = "0.54.0"
 edition = "2021"
 rust-version = "1.80"
 description = "A terminal file manager with mouse-resizable panes"

--- a/src/app/cmux.rs
+++ b/src/app/cmux.rs
@@ -1,33 +1,129 @@
-/// cmux integration — open files in new tab/surface.
+use super::opener::{default_rules, OpenerConfig};
+/// cmux integration — open files in a new surface or via a configured opener.
 ///
-/// Trek routes file opens to cmux when running inside a cmux workspace.
-/// The routing follows the table in CLAUDE.md:
-///   - HTML / images / PDFs → system default opener (open / xdg-open)
-///   - All other text/code  → new cmux terminal surface running $EDITOR
+/// File-open routing is now driven by the opener config
+/// (`~/.config/trek/opener.conf`).  When a user config is present, commands
+/// are read from it and executed via `sh -c`.  When no config exists the
+/// built-in defaults from `opener::default_rules` are used, which replicates
+/// the previous hardcoded behaviour:
 ///
-/// When Trek is not running inside cmux, a status-bar hint is shown instead
-/// so the user knows to use `o` for in-place editor access.
+/// - HTML / images / PDFs → system default opener (`open` / `xdg-open`)
+/// - All other text/code  → new cmux terminal surface running `$EDITOR`
+///
+/// When Trek is not running inside cmux and the built-in `$EDITOR` fallback
+/// applies, a status-bar hint is shown instead.
 use super::App;
-use std::path::Path;
 
-/// Determines how to open a file based on its extension.
-enum OpenTarget {
-    /// Open in a new cmux terminal surface with $EDITOR.
-    Editor,
-    /// Open with the platform system-default opener (background process).
-    SystemDefault,
-}
+impl App {
+    /// Open the selected file using the configured opener rules.
+    ///
+    /// Resolution order:
+    /// 1. User opener config (`~/.config/trek/opener.conf`) — first match wins.
+    /// 2. Built-in defaults — system open for binary types, `$EDITOR` in a new
+    ///    cmux surface for code/text.
+    ///
+    /// Does nothing when the selected entry is a directory.
+    pub fn open_in_cmux_tab(&mut self) {
+        let entry = match self.entries.get(self.selected).cloned() {
+            Some(e) if !e.is_dir => e,
+            _ => return,
+        };
 
-fn route_file(path: &Path) -> OpenTarget {
-    let ext = path
-        .extension()
-        .and_then(|e| e.to_str())
-        .unwrap_or("")
-        .to_lowercase();
-    match ext.as_str() {
-        "html" | "htm" | "pdf" | "png" | "jpg" | "jpeg" | "gif" | "svg" | "webp" | "ico"
-        | "bmp" | "tiff" | "tif" => OpenTarget::SystemDefault,
-        _ => OpenTarget::Editor,
+        // Prefer user config; fall back to built-in rules.
+        let config = OpenerConfig::load().unwrap_or_else(|| OpenerConfig {
+            rules: default_rules(),
+        });
+
+        let command_template = match config.find_command(&entry.path) {
+            Some(t) => t.to_owned(),
+            None => {
+                self.status_message = Some(format!("No opener rule matched: {}", entry.name));
+                return;
+            }
+        };
+
+        let expanded = OpenerConfig::expand_command(&command_template, &entry.path);
+
+        // Built-in `$EDITOR {}` — use cmux surface creation so the editor gets
+        // an interactive terminal.  All other commands (including user-config
+        // rules) are spawned via `sh -c` directly.
+        if command_template == "$EDITOR {}" {
+            self.open_in_editor_surface(&entry.name, &entry.path.to_string_lossy());
+        } else {
+            self.spawn_opener_command(&entry.name, &expanded);
+        }
+    }
+
+    /// Execute `command` via `sh -c` as a background subprocess.
+    ///
+    /// Used for all user-configured opener rules and for system-open commands
+    /// from the built-in defaults.
+    fn spawn_opener_command(&mut self, name: &str, command: &str) {
+        match std::process::Command::new("sh")
+            .args(["-c", command])
+            .spawn()
+        {
+            Ok(_) => {
+                self.status_message = Some(format!("Opening: {}", name));
+            }
+            Err(e) => {
+                self.status_message = Some(format!("Failed to open {}: {}", name, e));
+            }
+        }
+    }
+
+    /// Open `path` in a new cmux terminal surface running `$EDITOR`.
+    ///
+    /// Shows a status-bar hint when Trek is not running inside cmux.
+    fn open_in_editor_surface(&mut self, name: &str, path: &str) {
+        if std::env::var("CMUX_WORKSPACE_ID").is_err() {
+            self.status_message = Some("Not in cmux — use 'o' to open in editor".to_string());
+            return;
+        }
+
+        let editor = std::env::var("VISUAL")
+            .or_else(|_| std::env::var("EDITOR"))
+            .unwrap_or_else(|_| "vi".to_string());
+        let command = format!("{} {}", editor, shell_escape(path));
+
+        match std::process::Command::new("cmux")
+            .args(["new-surface", "--type", "terminal"])
+            .output()
+        {
+            Ok(out) if out.status.success() => {
+                let stdout = String::from_utf8_lossy(&out.stdout);
+                // Output format: "OK surface:N pane:N workspace:N"
+                let surface_ref = stdout
+                    .split_whitespace()
+                    .find(|s| s.starts_with("surface:"))
+                    .unwrap_or("")
+                    .to_string();
+
+                if surface_ref.is_empty() {
+                    self.status_message = Some("cmux: could not parse surface ref".to_string());
+                    return;
+                }
+
+                match std::process::Command::new("cmux")
+                    .args(["send", "--surface", &surface_ref, &format!("{}\r", command)])
+                    .status()
+                {
+                    Ok(_) => {
+                        self.status_message = Some(format!("Opened in new tab: {}", name));
+                    }
+                    Err(e) => {
+                        self.status_message = Some(format!("cmux send failed: {}", e));
+                    }
+                }
+            }
+            Ok(out) => {
+                let stderr = String::from_utf8_lossy(&out.stderr);
+                self.status_message = Some(format!("cmux error: {}", stderr.trim()));
+            }
+            Err(e) => {
+                self.status_message = Some(format!("cmux not available: {}", e));
+            }
+        }
     }
 }
 
@@ -40,97 +136,9 @@ fn shell_escape(s: &str) -> String {
     }
 }
 
-impl App {
-    /// Open the selected file in a new cmux tab.
-    ///
-    /// Routes by file type following the CLAUDE.md routing table. Does nothing
-    /// when the selected entry is a directory. Shows a status-bar hint when
-    /// Trek is not running inside cmux (CMUX_WORKSPACE_ID is unset).
-    pub fn open_in_cmux_tab(&mut self) {
-        let entry = match self.entries.get(self.selected).cloned() {
-            Some(e) if !e.is_dir => e,
-            _ => return,
-        };
-
-        if std::env::var("CMUX_WORKSPACE_ID").is_err() {
-            self.status_message = Some("Not in cmux — use 'o' to open in editor".to_string());
-            return;
-        }
-
-        let path = entry.path.to_string_lossy().into_owned();
-
-        match route_file(&entry.path) {
-            OpenTarget::SystemDefault => {
-                #[cfg(target_os = "macos")]
-                let opener = "open";
-                #[cfg(not(target_os = "macos"))]
-                let opener = "xdg-open";
-
-                match std::process::Command::new(opener).arg(&path).spawn() {
-                    Ok(_) => {
-                        self.status_message = Some(format!("Opening: {}", entry.name));
-                    }
-                    Err(e) => {
-                        self.status_message = Some(format!("Failed to open {}: {}", entry.name, e));
-                    }
-                }
-            }
-            OpenTarget::Editor => {
-                let editor = std::env::var("VISUAL")
-                    .or_else(|_| std::env::var("EDITOR"))
-                    .unwrap_or_else(|_| "vi".to_string());
-                let command = format!("{} {}", editor, shell_escape(&path));
-
-                // Create a new terminal surface in the current cmux workspace.
-                match std::process::Command::new("cmux")
-                    .args(["new-surface", "--type", "terminal"])
-                    .output()
-                {
-                    Ok(out) if out.status.success() => {
-                        let stdout = String::from_utf8_lossy(&out.stdout);
-                        // Output format: "OK surface:N pane:N workspace:N"
-                        let surface_ref = stdout
-                            .split_whitespace()
-                            .find(|s| s.starts_with("surface:"))
-                            .unwrap_or("")
-                            .to_string();
-
-                        if surface_ref.is_empty() {
-                            self.status_message =
-                                Some("cmux: could not parse surface ref".to_string());
-                            return;
-                        }
-
-                        match std::process::Command::new("cmux")
-                            .args(["send", "--surface", &surface_ref, &format!("{}\r", command)])
-                            .status()
-                        {
-                            Ok(_) => {
-                                self.status_message =
-                                    Some(format!("Opened in new tab: {}", entry.name));
-                            }
-                            Err(e) => {
-                                self.status_message = Some(format!("cmux send failed: {}", e));
-                            }
-                        }
-                    }
-                    Ok(out) => {
-                        let stderr = String::from_utf8_lossy(&out.stderr);
-                        self.status_message = Some(format!("cmux error: {}", stderr.trim()));
-                    }
-                    Err(e) => {
-                        self.status_message = Some(format!("cmux not available: {}", e));
-                    }
-                }
-            }
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::path::PathBuf;
 
     /// Given: a path with a space in it
     /// When: shell_escape is called
@@ -157,50 +165,5 @@ mod tests {
     fn shell_escape_handles_single_quote() {
         let result = shell_escape("/home/user/it's a file.txt");
         assert_eq!(result, "'/home/user/it'\\''s a file.txt'");
-    }
-
-    /// Given: an HTML file path
-    /// When: route_file is called
-    /// Then: returns SystemDefault
-    #[test]
-    fn route_file_html_uses_system_default() {
-        let path = PathBuf::from("index.html");
-        assert!(matches!(route_file(&path), OpenTarget::SystemDefault));
-    }
-
-    /// Given: a PDF file path
-    /// When: route_file is called
-    /// Then: returns SystemDefault
-    #[test]
-    fn route_file_pdf_uses_system_default() {
-        let path = PathBuf::from("doc.pdf");
-        assert!(matches!(route_file(&path), OpenTarget::SystemDefault));
-    }
-
-    /// Given: a PNG image file path
-    /// When: route_file is called
-    /// Then: returns SystemDefault
-    #[test]
-    fn route_file_image_uses_system_default() {
-        let path = PathBuf::from("photo.png");
-        assert!(matches!(route_file(&path), OpenTarget::SystemDefault));
-    }
-
-    /// Given: a Rust source file path
-    /// When: route_file is called
-    /// Then: returns Editor
-    #[test]
-    fn route_file_code_uses_editor() {
-        let path = PathBuf::from("main.rs");
-        assert!(matches!(route_file(&path), OpenTarget::Editor));
-    }
-
-    /// Given: a Markdown file path
-    /// When: route_file is called
-    /// Then: returns Editor (markdown opens in editor by default)
-    #[test]
-    fn route_file_markdown_uses_editor() {
-        let path = PathBuf::from("README.md");
-        assert!(matches!(route_file(&path), OpenTarget::Editor));
     }
 }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -20,6 +20,7 @@ mod layout;
 mod metadata;
 mod mouse;
 mod navigation;
+pub mod opener;
 pub mod palette;
 mod palette_ops;
 mod preview;

--- a/src/app/opener.rs
+++ b/src/app/opener.rs
@@ -1,0 +1,577 @@
+/// Rifle-style configurable file opener rules.
+///
+/// Trek loads opener rules from `$XDG_CONFIG_HOME/trek/opener.conf`
+/// (falling back to `~/.config/trek/opener.conf`). Rules are evaluated
+/// top-to-bottom; the first matching rule wins. When no config file is found,
+/// built-in defaults replicate the prior hardcoded routing behaviour.
+///
+/// # Config format
+///
+/// ```text
+/// # Lines beginning with # are comments. Blank lines are ignored.
+/// # Format:  <matcher> <pattern> : <command>
+/// #
+/// # Matchers:
+/// #   ext <ext1|ext2|...>   — file extension match (case-insensitive)
+/// #   glob <pattern>        — shell glob match against the filename
+/// #
+/// # Use {} as the placeholder for the file path in the command.
+/// # The command is executed via the system shell (sh -c).
+///
+/// ext md|markdown : cmux open --md {}
+/// ext html|htm    : open {}
+/// glob *          : $EDITOR {}
+/// ```
+use std::path::Path;
+
+/// A single opener rule mapping a file pattern to a command.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OpenerRule {
+    pub matcher: Matcher,
+    /// Command template.  `{}` is replaced with the quoted file path.
+    pub command: String,
+}
+
+/// The pattern half of an opener rule.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Matcher {
+    /// Match by file extension (case-insensitive). Multiple extensions
+    /// separated by `|` in the config are stored as individual strings.
+    Ext(Vec<String>),
+    /// Shell glob matched against the file **name** (not the full path).
+    Glob(String),
+}
+
+impl Matcher {
+    /// Returns `true` when this matcher applies to `path`.
+    pub fn matches(&self, path: &Path) -> bool {
+        match self {
+            Matcher::Ext(exts) => {
+                let file_ext = path
+                    .extension()
+                    .and_then(|e| e.to_str())
+                    .unwrap_or("")
+                    .to_lowercase();
+                exts.iter().any(|e| e == &file_ext)
+            }
+            Matcher::Glob(pattern) => {
+                let filename = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+                glob_match(pattern, filename)
+            }
+        }
+    }
+}
+
+/// Minimal glob implementation supporting `*` (any sequence) and `?` (one char).
+///
+/// Matching is against the full pattern — the pattern must cover the entire
+/// filename, not just a substring. This is sufficient for the common cases
+/// (`*`, `*.rs`, `Makefile`).
+fn glob_match(pattern: &str, text: &str) -> bool {
+    let p: Vec<char> = pattern.chars().collect();
+    let t: Vec<char> = text.chars().collect();
+    glob_match_inner(&p, &t)
+}
+
+fn glob_match_inner(p: &[char], t: &[char]) -> bool {
+    match (p, t) {
+        ([], []) => true,
+        ([], _) => false,
+        (['*', rest @ ..], _) => {
+            // `*` matches zero or more characters.
+            if glob_match_inner(rest, t) {
+                return true;
+            }
+            for i in 0..t.len() {
+                if glob_match_inner(rest, &t[i + 1..]) {
+                    return true;
+                }
+            }
+            false
+        }
+        (['?', p_rest @ ..], [_, t_rest @ ..]) => glob_match_inner(p_rest, t_rest),
+        (['?', ..], []) => false,
+        ([pc, p_rest @ ..], [tc, t_rest @ ..]) if pc == tc => glob_match_inner(p_rest, t_rest),
+        _ => false,
+    }
+}
+
+/// The loaded opener configuration.
+#[derive(Debug, Clone, Default)]
+pub struct OpenerConfig {
+    pub rules: Vec<OpenerRule>,
+}
+
+impl OpenerConfig {
+    /// Load the opener config from the standard config path.
+    ///
+    /// Returns `None` when the config file does not exist. Returns an empty
+    /// config (not `None`) when the file exists but contains only comments or
+    /// blank lines.
+    pub fn load() -> Option<Self> {
+        let path = config_path()?;
+        let text = std::fs::read_to_string(&path).ok()?;
+        Some(Self::parse(&text))
+    }
+
+    /// Parse a config file body into an `OpenerConfig`.
+    ///
+    /// Lines that cannot be parsed are silently skipped so that a single bad
+    /// rule does not break all file opens.
+    pub fn parse(text: &str) -> Self {
+        let rules = text.lines().filter_map(parse_line).collect();
+        Self { rules }
+    }
+
+    /// Find the first rule matching `path` and return its command template.
+    ///
+    /// Returns `None` when no rule matches.
+    pub fn find_command(&self, path: &Path) -> Option<&str> {
+        self.rules
+            .iter()
+            .find(|r| r.matcher.matches(path))
+            .map(|r| r.command.as_str())
+    }
+
+    /// Expand a command template by substituting `{}` with the shell-escaped
+    /// file path.
+    ///
+    /// If the template does not contain `{}`, the path is appended with a
+    /// space separator.
+    pub fn expand_command(template: &str, path: &Path) -> String {
+        let path_str = path.to_string_lossy();
+        let escaped = shell_escape_path(&path_str);
+        if template.contains("{}") {
+            template.replace("{}", &escaped)
+        } else {
+            format!("{} {}", template, escaped)
+        }
+    }
+}
+
+/// Built-in default opener rules used when no config file is present.
+///
+/// These replicate the previous hardcoded routing behaviour:
+/// - Binary/document types → system default opener (`open` / `xdg-open`)
+/// - Everything else → `$EDITOR`
+pub fn default_rules() -> Vec<OpenerRule> {
+    vec![
+        OpenerRule {
+            matcher: Matcher::Ext(vec![
+                "html".into(),
+                "htm".into(),
+                "pdf".into(),
+                "png".into(),
+                "jpg".into(),
+                "jpeg".into(),
+                "gif".into(),
+                "svg".into(),
+                "webp".into(),
+                "ico".into(),
+                "bmp".into(),
+                "tiff".into(),
+                "tif".into(),
+            ]),
+            command: system_open_command().to_string(),
+        },
+        OpenerRule {
+            matcher: Matcher::Glob("*".into()),
+            command: "$EDITOR {}".into(),
+        },
+    ]
+}
+
+/// Returns the platform-appropriate system-open command with `{}` placeholder.
+pub fn system_open_command() -> &'static str {
+    #[cfg(target_os = "macos")]
+    return "open {}";
+    #[cfg(not(target_os = "macos"))]
+    return "xdg-open {}";
+}
+
+/// Resolve the opener config file path, respecting `$XDG_CONFIG_HOME`.
+fn config_path() -> Option<std::path::PathBuf> {
+    let base = std::env::var("XDG_CONFIG_HOME")
+        .ok()
+        .map(std::path::PathBuf::from)
+        .or_else(dirs_config_home)?;
+    Some(base.join("trek").join("opener.conf"))
+}
+
+/// Returns `~/.config` as a `PathBuf`, or `None` if `$HOME` is unset.
+fn dirs_config_home() -> Option<std::path::PathBuf> {
+    let home = std::env::var("HOME").ok()?;
+    Some(std::path::PathBuf::from(home).join(".config"))
+}
+
+/// Parse a single config line into an `OpenerRule`.
+///
+/// Expected formats:
+/// - `ext <exts> : <command>`
+/// - `glob <pattern> : <command>`
+///
+/// Returns `None` for blank lines and comment lines (starting with `#`).
+fn parse_line(line: &str) -> Option<OpenerRule> {
+    let trimmed = line.trim();
+    if trimmed.is_empty() || trimmed.starts_with('#') {
+        return None;
+    }
+
+    let (lhs, command) = trimmed.split_once(':')?;
+    let command = command.trim().to_string();
+    if command.is_empty() {
+        return None;
+    }
+
+    let mut parts = lhs.split_whitespace();
+    let kind = parts.next()?;
+    let pattern = parts.next()?;
+
+    match kind {
+        "ext" => {
+            let exts: Vec<String> = pattern
+                .split('|')
+                .map(|e| e.trim().to_lowercase())
+                .filter(|e| !e.is_empty())
+                .collect();
+            if exts.is_empty() {
+                return None;
+            }
+            Some(OpenerRule {
+                matcher: Matcher::Ext(exts),
+                command,
+            })
+        }
+        "glob" => Some(OpenerRule {
+            matcher: Matcher::Glob(pattern.to_string()),
+            command,
+        }),
+        _ => None,
+    }
+}
+
+/// Shell-escape a path for safe interpolation into a command string.
+///
+/// Wraps in single quotes and escapes any embedded single quotes.
+fn shell_escape_path(s: &str) -> String {
+    if s.chars()
+        .any(|c| " '\"\t\n\\()[]{};&|<>*?$`!#~".contains(c))
+    {
+        format!("'{}'", s.replace('\'', "'\\''"))
+    } else {
+        s.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    // ── Matcher::Ext ──────────────────────────────────────────────────────────
+
+    /// Given: an Ext matcher for "rs"
+    /// When: path with extension "rs" is tested
+    /// Then: matches returns true
+    #[test]
+    fn ext_matcher_matches_correct_extension() {
+        let m = Matcher::Ext(vec!["rs".into()]);
+        assert!(m.matches(Path::new("main.rs")));
+    }
+
+    /// Given: an Ext matcher for "rs"
+    /// When: path with extension "md" is tested
+    /// Then: matches returns false
+    #[test]
+    fn ext_matcher_rejects_wrong_extension() {
+        let m = Matcher::Ext(vec!["rs".into()]);
+        assert!(!m.matches(Path::new("README.md")));
+    }
+
+    /// Given: an Ext matcher with multiple extensions
+    /// When: each extension is tested
+    /// Then: all match
+    #[test]
+    fn ext_matcher_matches_any_of_multiple_extensions() {
+        let m = Matcher::Ext(vec!["html".into(), "htm".into()]);
+        assert!(m.matches(Path::new("index.html")));
+        assert!(m.matches(Path::new("page.htm")));
+        assert!(!m.matches(Path::new("script.js")));
+    }
+
+    /// Given: an Ext matcher for lowercase "rs"
+    /// When: a path with uppercase extension "RS" is tested
+    /// Then: matches (case-insensitive)
+    #[test]
+    fn ext_matcher_is_case_insensitive() {
+        let m = Matcher::Ext(vec!["rs".into()]);
+        assert!(m.matches(Path::new("main.RS")));
+    }
+
+    /// Given: an Ext matcher for "rs"
+    /// When: a path with no extension is tested
+    /// Then: does not match
+    #[test]
+    fn ext_matcher_rejects_no_extension() {
+        let m = Matcher::Ext(vec!["rs".into()]);
+        assert!(!m.matches(Path::new("Makefile")));
+    }
+
+    // ── Matcher::Glob ─────────────────────────────────────────────────────────
+
+    /// Given: a Glob matcher with pattern "*"
+    /// When: any filename is tested
+    /// Then: always matches
+    #[test]
+    fn glob_star_matches_everything() {
+        let m = Matcher::Glob("*".into());
+        assert!(m.matches(Path::new("anything.rs")));
+        assert!(m.matches(Path::new("Makefile")));
+        assert!(m.matches(Path::new(".hidden")));
+    }
+
+    /// Given: a Glob matcher with pattern "*.rs"
+    /// When: a Rust file is tested
+    /// Then: matches
+    #[test]
+    fn glob_star_rs_matches_rust_files() {
+        let m = Matcher::Glob("*.rs".into());
+        assert!(m.matches(Path::new("main.rs")));
+        assert!(!m.matches(Path::new("main.py")));
+    }
+
+    /// Given: a Glob matcher with pattern "Make*"
+    /// When: "Makefile" is tested
+    /// Then: matches
+    #[test]
+    fn glob_prefix_star_matches() {
+        let m = Matcher::Glob("Make*".into());
+        assert!(m.matches(Path::new("Makefile")));
+        assert!(m.matches(Path::new("Makefile.am")));
+        assert!(!m.matches(Path::new("GNUmakefile")));
+    }
+
+    /// Given: a Glob matcher with "?" wildcard
+    /// When: a filename with that single-char slot is tested
+    /// Then: matches correctly
+    #[test]
+    fn glob_question_mark_matches_single_char() {
+        let m = Matcher::Glob("file?.txt".into());
+        assert!(m.matches(Path::new("file1.txt")));
+        assert!(m.matches(Path::new("fileA.txt")));
+        assert!(!m.matches(Path::new("file.txt")));
+        assert!(!m.matches(Path::new("file12.txt")));
+    }
+
+    // ── OpenerConfig::parse ───────────────────────────────────────────────────
+
+    /// Given: a valid config with one ext rule and one glob rule
+    /// When: parse is called
+    /// Then: two rules are returned in order
+    #[test]
+    fn parse_returns_rules_in_order() {
+        let config = OpenerConfig::parse("ext html|htm : open {}\nglob * : $EDITOR {}");
+        assert_eq!(config.rules.len(), 2);
+        assert_eq!(config.rules[0].command, "open {}");
+        assert_eq!(config.rules[1].command, "$EDITOR {}");
+    }
+
+    /// Given: config with comment and blank lines
+    /// When: parse is called
+    /// Then: comments and blanks are ignored
+    #[test]
+    fn parse_ignores_comments_and_blanks() {
+        let config = OpenerConfig::parse("# comment\n\next rs : code {}\n\n# another comment");
+        assert_eq!(config.rules.len(), 1);
+    }
+
+    /// Given: config with an unrecognised matcher kind
+    /// When: parse is called
+    /// Then: that line is silently skipped
+    #[test]
+    fn parse_skips_unknown_matcher_kind() {
+        let config = OpenerConfig::parse("mime text/plain : less {}\next rs : code {}");
+        assert_eq!(config.rules.len(), 1);
+        assert_eq!(config.rules[0].command, "code {}");
+    }
+
+    /// Given: an ext rule with multiple pipe-separated extensions
+    /// When: parse is called
+    /// Then: all extensions are captured
+    #[test]
+    fn parse_splits_pipe_separated_extensions() {
+        let config = OpenerConfig::parse("ext png|jpg|jpeg : open {}");
+        assert_eq!(config.rules.len(), 1);
+        if let Matcher::Ext(exts) = &config.rules[0].matcher {
+            assert_eq!(exts, &["png", "jpg", "jpeg"]);
+        } else {
+            panic!("expected Ext matcher");
+        }
+    }
+
+    // ── OpenerConfig::find_command ────────────────────────────────────────────
+
+    /// Given: a config with an ext rule for "html"
+    /// When: find_command is called with an html path
+    /// Then: returns the matching command
+    #[test]
+    fn find_command_returns_matching_rule() {
+        let config = OpenerConfig::parse("ext html : open {}\nglob * : $EDITOR {}");
+        let cmd = config.find_command(Path::new("index.html"));
+        assert_eq!(cmd, Some("open {}"));
+    }
+
+    /// Given: a config with an ext rule for "html" followed by a glob "*"
+    /// When: find_command is called with a non-html path
+    /// Then: returns the glob fallback
+    #[test]
+    fn find_command_falls_back_to_glob_star() {
+        let config = OpenerConfig::parse("ext html : open {}\nglob * : $EDITOR {}");
+        let cmd = config.find_command(Path::new("main.rs"));
+        assert_eq!(cmd, Some("$EDITOR {}"));
+    }
+
+    /// Given: a config where the first matching rule is ext, not glob
+    /// When: find_command is called
+    /// Then: first-match-wins: ext rule is returned, not the glob
+    #[test]
+    fn find_command_first_match_wins() {
+        let config =
+            OpenerConfig::parse("glob * : first {}\next rs : second {}\nglob * : third {}");
+        let cmd = config.find_command(Path::new("main.rs"));
+        assert_eq!(cmd, Some("first {}"));
+    }
+
+    /// Given: an empty config
+    /// When: find_command is called
+    /// Then: returns None
+    #[test]
+    fn find_command_returns_none_when_no_rules() {
+        let config = OpenerConfig::parse("");
+        assert_eq!(config.find_command(Path::new("main.rs")), None);
+    }
+
+    // ── OpenerConfig::expand_command ─────────────────────────────────────────
+
+    /// Given: a command template with "{}"
+    /// When: expand_command is called with a simple path
+    /// Then: "{}" is replaced by the path
+    #[test]
+    fn expand_command_substitutes_placeholder() {
+        let result = OpenerConfig::expand_command("open {}", Path::new("/tmp/file.txt"));
+        assert_eq!(result, "open /tmp/file.txt");
+    }
+
+    /// Given: a command template with "{}" and a path containing spaces
+    /// When: expand_command is called
+    /// Then: path is shell-quoted
+    #[test]
+    fn expand_command_quotes_paths_with_spaces() {
+        let result = OpenerConfig::expand_command("open {}", Path::new("/home/user/my file.txt"));
+        assert_eq!(result, "open '/home/user/my file.txt'");
+    }
+
+    /// Given: a command template without "{}"
+    /// When: expand_command is called
+    /// Then: path is appended with a space
+    #[test]
+    fn expand_command_appends_path_when_no_placeholder() {
+        let result = OpenerConfig::expand_command("open", Path::new("/tmp/file.txt"));
+        assert_eq!(result, "open /tmp/file.txt");
+    }
+
+    // ── default_rules ─────────────────────────────────────────────────────────
+
+    /// Given: the default rules
+    /// When: find_command is called with an HTML file
+    /// Then: returns a system-open command
+    #[test]
+    fn default_rules_route_html_to_system_open() {
+        let config = OpenerConfig {
+            rules: default_rules(),
+        };
+        let cmd = config.find_command(Path::new("index.html")).unwrap_or("");
+        assert!(
+            cmd.starts_with("open") || cmd.starts_with("xdg-open"),
+            "expected system open command, got: {}",
+            cmd
+        );
+    }
+
+    /// Given: the default rules
+    /// When: find_command is called with a Rust source file
+    /// Then: returns the $EDITOR fallback
+    #[test]
+    fn default_rules_route_code_to_editor() {
+        let config = OpenerConfig {
+            rules: default_rules(),
+        };
+        let cmd = config.find_command(Path::new("main.rs")).unwrap_or("");
+        assert_eq!(cmd, "$EDITOR {}");
+    }
+
+    /// Given: the default rules
+    /// When: find_command is called with a PNG image
+    /// Then: returns a system-open command
+    #[test]
+    fn default_rules_route_image_to_system_open() {
+        let config = OpenerConfig {
+            rules: default_rules(),
+        };
+        let cmd = config.find_command(Path::new("photo.png")).unwrap_or("");
+        assert!(
+            cmd.starts_with("open") || cmd.starts_with("xdg-open"),
+            "expected system open command, got: {}",
+            cmd
+        );
+    }
+
+    // ── shell_escape_path ─────────────────────────────────────────────────────
+
+    /// Given: a path with no special characters
+    /// When: shell_escape_path is called
+    /// Then: path is returned unchanged
+    #[test]
+    fn shell_escape_path_leaves_simple_paths_unchanged() {
+        assert_eq!(
+            shell_escape_path("/home/user/file.txt"),
+            "/home/user/file.txt"
+        );
+    }
+
+    /// Given: a path with a space
+    /// When: shell_escape_path is called
+    /// Then: path is wrapped in single quotes
+    #[test]
+    fn shell_escape_path_quotes_paths_with_spaces() {
+        assert_eq!(
+            shell_escape_path("/home/user/my file.txt"),
+            "'/home/user/my file.txt'"
+        );
+    }
+
+    /// Given: a path with a single quote
+    /// When: shell_escape_path is called
+    /// Then: single quote is escaped within the quoting
+    #[test]
+    fn shell_escape_path_handles_single_quote() {
+        assert_eq!(
+            shell_escape_path("/home/user/it's"),
+            "'/home/user/it'\\''s'"
+        );
+    }
+
+    // ── OpenerConfig::load from file ──────────────────────────────────────────
+
+    /// Given: a temporary config file with valid rules
+    /// When: OpenerConfig::parse is called with its contents
+    /// Then: rules are loaded correctly
+    #[test]
+    fn parse_loads_config_from_text() {
+        let text = "# opener config\next md : cmux open --md {}\nglob * : $EDITOR {}";
+        let config = OpenerConfig::parse(text);
+        assert_eq!(config.rules.len(), 2);
+        assert_eq!(config.rules[0].matcher, Matcher::Ext(vec!["md".into()]));
+        assert_eq!(config.rules[0].command, "cmux open --md {}");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `~/.config/trek/opener.conf` (or `$XDG_CONFIG_HOME/trek/opener.conf`) — a rifle-style config for routing files to custom openers
- Rules are evaluated top-to-bottom; first match wins. Matchers: `ext <ext1|ext2>` and `glob <pattern>`. Use `{}` as the file path placeholder.
- User-configured commands execute via `sh -c`, enabling full shell syntax and env var expansion
- Built-in defaults preserved when no config exists (system open for HTML/images/PDFs, `$EDITOR` in a new cmux surface for code)

**Example config:**
```
# Open markdown in cmux viewer
ext md|markdown : cmux open --md {}
# Open HTML in browser
ext html|htm : open {}
# Fallback: open code in VS Code
glob * : code {}
```

## Implementation

- New module `src/app/opener.rs`: `OpenerConfig`, `OpenerRule`, `Matcher` (Ext/Glob), and a minimal glob engine
- `cmux.rs` refactored to delegate routing to `OpenerConfig` instead of the previous hardcoded `route_file` function
- 27 new tests covering all matching, parsing, command expansion, and default-rule behaviour

## Test plan

- [x] `cargo test` — 291 tests pass, 0 failures
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo build --release` — succeeds
- [x] `cargo fmt` — applied

Closes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)