### PR TITLE
fix(preview): TOML syntax highlighting via two-face extended grammar set (v0.56.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.56.1] - 2026-03-24
+
+### Fixed
+- **TOML syntax highlighting** — `.toml` files (e.g. `Cargo.toml`) now render with full syntax highlighting in the preview pane. The bundled syntax set has been switched from Sublime Text's default package (which lacks TOML) to the `two-face` extended set — the same set used by `bat` — which includes TOML, Dockerfile, `.env`, and dozens of other types not covered by the defaults. `.yaml`, `.json`, `.rs`, and all previously-supported types are unaffected.
+
 ## [0.56.0] - 2026-03-24
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,6 +87,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cc"
+version = "1.2.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -197,6 +207,12 @@ dependencies = [
  "libc",
  "libredox",
 ]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "flate2"
@@ -417,6 +433,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "onig"
+version = "6.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "336b9c63443aceef14bea841b899035ae3abe89b7c486aaf4c5bd8aafedac3f0"
+dependencies = [
+ "bitflags 2.11.0",
+ "libc",
+ "once_cell",
+ "onig_sys",
+]
+
+[[package]]
+name = "onig_sys"
+version = "69.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f86c6eef3d6df15f23bcfb6af487cbd2fed4e5581d58d5bf1f5f8b7f6727dc"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -444,6 +482,12 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plain"
@@ -593,6 +637,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "signal-hook"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -695,6 +745,7 @@ dependencies = [
  "flate2",
  "fnv",
  "once_cell",
+ "onig",
  "regex-syntax",
  "serde",
  "serde_derive",
@@ -724,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "trek"
-version = "0.56.0"
+version = "0.56.1"
 dependencies = [
  "anyhow",
  "base64",
@@ -733,6 +784,18 @@ dependencies = [
  "notify-debouncer-mini",
  "ratatui",
  "regex",
+ "syntect",
+ "two-face",
+]
+
+[[package]]
+name = "two-face"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39e51b6e60e545cfdae5a4639ff423818f52372211a8d9a3e892b4b0761f76b2"
+dependencies = [
+ "serde",
+ "serde_derive",
  "syntect",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trek"
-version = "0.56.0"
+version = "0.56.1"
 edition = "2021"
 rust-version = "1.80"
 description = "A terminal file manager with mouse-resizable panes"
@@ -15,5 +15,6 @@ anyhow = "1"
 base64 = "0.22"
 regex = "1"
 syntect = { version = "5", default-features = false, features = ["default-syntaxes", "default-themes", "regex-fancy"] }
+two-face = "0.4"
 notify = "6"
 notify-debouncer-mini = "0.4"

--- a/src/highlight.rs
+++ b/src/highlight.rs
@@ -14,10 +14,13 @@ pub struct Highlighter {
 
 impl Highlighter {
     /// Load bundled syntax definitions and themes. Call once at startup.
+    ///
+    /// Uses `two-face`'s extended syntax set (the same set `bat` uses) which
+    /// includes TOML, Dockerfile, `.env`, and many other types absent from
+    /// Sublime Text's default bundle.
     pub fn new() -> Self {
-        // Stub — does NOT load real data. Tests will fail.
         Self {
-            syntax_set: SyntaxSet::load_defaults_newlines(),
+            syntax_set: two_face::syntax::extra_newlines(),
             theme_set: ThemeSet::load_defaults(),
         }
     }
@@ -140,5 +143,31 @@ mod tests {
         let h = hl();
         let lines = vec!["key: value".to_string(), "list:".to_string()];
         assert!(h.highlight(&lines, "yaml", 100).is_some());
+    }
+
+    /// Given: a .toml extension
+    /// When: highlight is called
+    /// Then: Some is returned (TOML grammar is available)
+    #[test]
+    fn highlight_toml_returns_some() {
+        let h = hl();
+        let lines = vec![r#"[package]"#.to_string(), r#"name = "trek""#.to_string()];
+        assert!(
+            h.highlight(&lines, "toml", 100).is_some(),
+            "expected Some for .toml — TOML grammar must be available"
+        );
+    }
+
+    /// Given: a .json extension
+    /// When: highlight is called
+    /// Then: Some is returned (JSON grammar is available)
+    #[test]
+    fn highlight_json_returns_some() {
+        let h = hl();
+        let lines = vec![r#"{"key": "value"}"#.to_string()];
+        assert!(
+            h.highlight(&lines, "json", 100).is_some(),
+            "expected Some for .json — JSON grammar must be available"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Fixes #111 — `.toml` files (including `Cargo.toml`) rendered as plain text because Sublime Text's default SyntaxSet doesn't include a TOML grammar
- Switches `SyntaxSet::load_defaults_newlines()` → `two_face::syntax::extra_newlines()`, the same extended syntax set used by `bat`
- Covers TOML, Dockerfile, `.env`, and dozens of other types not in the Sublime defaults — all previously supported types (YAML, JSON, Rust, Python…) continue working

## Test plan

- [ ] `cargo test` — 306 tests pass including new `highlight_toml_returns_some` and `highlight_json_returns_some`
- [ ] `cargo clippy -- -D warnings` — clean
- [ ] `cargo build --release` — succeeds
- [ ] Navigate to `Cargo.toml` in Trek — preview shows TOML syntax highlighting
- [ ] Navigate to a `.yaml` / `.rs` / `.py` file — highlighting unchanged (no regression)

Fixes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)