### PR TITLE
feat(preview): rich image and PDF preview with chafa/pdfinfo integration (#97)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.58.0] - 2026-03-24
+
+### Added
+- **Image and PDF preview** — raster image files (`.png`, `.jpg`, `.jpeg`, `.gif`, `.bmp`, `.ico`, `.webp`, `.avif`, `.tiff`) and `.pdf` files now display a rich metadata card in the preview pane instead of the previous `[binary file]` placeholder. The card shows format, file size, and pixel dimensions (for images) or PDF version (for PDFs). When [`chafa`](https://hpjansson.org/chafa/) is installed, images are additionally rendered as full-color Unicode/sixel art inline in the preview pane at 72 columns. When [`pdfinfo`](https://poppler.freedesktop.org/) (poppler-utils) is installed, PDFs display their full document metadata. Both tools degrade gracefully when absent — a short install hint is shown instead. SVG files continue to preview as plain-text XML through the existing text path.
+
 ## [0.57.0] - 2026-03-24
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,6 +263,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "imagesize"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "029d73f573d8e8d63e6d5020011d3255b28c3ba85d6cf870a07184ed23de9284"
+
+[[package]]
 name = "inotify"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -775,11 +781,12 @@ dependencies = [
 
 [[package]]
 name = "trek"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "anyhow",
  "base64",
  "crossterm",
+ "imagesize",
  "notify",
  "notify-debouncer-mini",
  "ratatui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trek"
-version = "0.57.0"
+version = "0.58.0"
 edition = "2021"
 rust-version = "1.80"
 description = "A terminal file manager with mouse-resizable panes"
@@ -18,3 +18,4 @@ syntect = { version = "5", default-features = false, features = ["default-syntax
 two-face = "0.4"
 notify = "6"
 notify-debouncer-mini = "0.4"
+imagesize = "0.12"

--- a/src/app/preview.rs
+++ b/src/app/preview.rs
@@ -39,6 +39,12 @@ enum PreviewJob {
     FileContent {
         path: PathBuf,
     },
+    ImagePreview {
+        path: PathBuf,
+    },
+    PdfPreview {
+        path: PathBuf,
+    },
     DirectoryListing {
         path: PathBuf,
         show_hidden: bool,
@@ -92,6 +98,14 @@ impl PreviewJob {
             }
             PreviewJob::FileContent { path } => PreviewResult {
                 lines: App::read_file_preview(&path),
+                is_diff: false,
+            },
+            PreviewJob::ImagePreview { path } => PreviewResult {
+                lines: build_image_preview_lines(&path),
+                is_diff: false,
+            },
+            PreviewJob::PdfPreview { path } => PreviewResult {
+                lines: build_pdf_preview_lines(&path),
                 is_diff: false,
             },
             PreviewJob::DirectoryListing {
@@ -195,6 +209,14 @@ impl App {
                 return PreviewJob::GitDiff {
                     path: entry.path.clone(),
                     has_change,
+                };
+            } else if is_image_path(&entry.path) {
+                return PreviewJob::ImagePreview {
+                    path: entry.path.clone(),
+                };
+            } else if is_pdf_path(&entry.path) {
+                return PreviewJob::PdfPreview {
+                    path: entry.path.clone(),
                 };
             } else {
                 return PreviewJob::FileContent {
@@ -622,5 +644,252 @@ impl App {
             lines.push(format!("  {:<30}  {:>10}  {}", name, human, bar));
         }
         lines
+    }
+}
+
+// ── Image / PDF preview helpers ───────────────────────────────────────────
+
+/// Returns `true` when `path` has a binary raster image extension.
+///
+/// SVG is intentionally excluded — it is plain-text XML and previews fine
+/// through the normal text path.
+fn is_image_path(path: &Path) -> bool {
+    matches!(
+        path.extension()
+            .and_then(|e| e.to_str())
+            .map(|e| e.to_ascii_lowercase())
+            .as_deref(),
+        Some("png" | "jpg" | "jpeg" | "gif" | "bmp" | "ico" | "webp" | "avif" | "tiff" | "tif")
+    )
+}
+
+/// Returns `true` when `path` has the `.pdf` extension.
+fn is_pdf_path(path: &Path) -> bool {
+    path.extension()
+        .and_then(|e| e.to_str())
+        .map(|e| e.eq_ignore_ascii_case("pdf"))
+        .unwrap_or(false)
+}
+
+/// Build preview lines for a raster image file.
+///
+/// Shows format, pixel dimensions (via `imagesize`), file size, and — when
+/// `chafa` is available on `$PATH` — a Unicode/sixel art rendering of the
+/// image at the preview pane's approximate width (72 columns).
+fn build_image_preview_lines(path: &Path) -> Vec<String> {
+    let mut lines: Vec<String> = Vec::new();
+
+    // Format label from extension.
+    let fmt = path
+        .extension()
+        .and_then(|e| e.to_str())
+        .unwrap_or("image")
+        .to_ascii_uppercase();
+
+    // File size.
+    let size_str = std::fs::metadata(path)
+        .map(|m| human_bytes(m.len()))
+        .unwrap_or_else(|_| "?".to_string());
+
+    // Pixel dimensions via imagesize (reads just the header, not the whole file).
+    let dim_str = match imagesize::size(path) {
+        Ok(dim) => format!("{} × {}", dim.width, dim.height),
+        Err(_) => "unknown dimensions".to_string(),
+    };
+
+    lines.push(format!("  Format    {}", fmt));
+    lines.push(format!("  Size      {}", size_str));
+    lines.push(format!("  Dimensions  {}", dim_str));
+    lines.push(String::new());
+
+    // Try chafa for a visual text rendering. Graceful no-op if not installed.
+    let chafa_out = std::process::Command::new("chafa")
+        .args([
+            "--size=72x36",
+            "--colors=256",
+            "--",
+            &path.to_string_lossy(),
+        ])
+        .output();
+    if let Ok(out) = chafa_out {
+        if out.status.success() && !out.stdout.is_empty() {
+            let rendered = String::from_utf8_lossy(&out.stdout);
+            lines.extend(rendered.lines().map(|l| l.to_string()));
+            return lines;
+        }
+    }
+
+    // No chafa — show a hint.
+    lines.push("  [install chafa for inline image preview]".to_string());
+    lines
+}
+
+/// Build preview lines for a PDF file.
+///
+/// Shows file size and PDF version from the header.  When `pdfinfo` (from
+/// poppler-utils) is available it is used for richer metadata; otherwise a
+/// concise header-only summary is returned.
+fn build_pdf_preview_lines(path: &Path) -> Vec<String> {
+    let mut lines: Vec<String> = Vec::new();
+
+    let size_str = std::fs::metadata(path)
+        .map(|m| human_bytes(m.len()))
+        .unwrap_or_else(|_| "?".to_string());
+
+    // Read PDF version from the `%PDF-x.y` header (first 16 bytes).
+    let version = std::fs::File::open(path)
+        .ok()
+        .and_then(|mut f| {
+            use std::io::Read;
+            let mut buf = [0u8; 16];
+            f.read_exact(&mut buf).ok()?;
+            let header = std::str::from_utf8(&buf).ok()?;
+            let v = header.strip_prefix("%PDF-")?;
+            Some(v.split_whitespace().next().unwrap_or("").to_string())
+        })
+        .unwrap_or_default();
+
+    lines.push("  Format    PDF".to_string());
+    if !version.is_empty() {
+        lines.push(format!("  Version   {}", version));
+    }
+    lines.push(format!("  Size      {}", size_str));
+    lines.push(String::new());
+
+    // Try pdfinfo for rich metadata.
+    let pdfinfo = std::process::Command::new("pdfinfo")
+        .arg(path.to_string_lossy().as_ref())
+        .output();
+    if let Ok(out) = pdfinfo {
+        if out.status.success() && !out.stdout.is_empty() {
+            let info = String::from_utf8_lossy(&out.stdout);
+            lines.extend(info.lines().map(|l| format!("  {}", l)));
+            return lines;
+        }
+    }
+
+    lines.push("  [install pdfinfo (poppler-utils) for detailed metadata]".to_string());
+    lines
+}
+
+/// Format a byte count as a human-readable string (e.g. "1.2 MB").
+fn human_bytes(n: u64) -> String {
+    const KB: u64 = 1024;
+    const MB: u64 = 1024 * KB;
+    const GB: u64 = 1024 * MB;
+    if n >= GB {
+        format!("{:.1} GB", n as f64 / GB as f64)
+    } else if n >= MB {
+        format!("{:.1} MB", n as f64 / MB as f64)
+    } else if n >= KB {
+        format!("{:.1} KB", n as f64 / KB as f64)
+    } else {
+        format!("{} B", n)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    /// Given: a path with a .png extension
+    /// When: is_image_path is called
+    /// Then: returns true
+    #[test]
+    fn is_image_path_recognises_png() {
+        assert!(is_image_path(&PathBuf::from("photo.png")));
+    }
+
+    /// Given: a path with a .jpg extension
+    /// When: is_image_path is called
+    /// Then: returns true
+    #[test]
+    fn is_image_path_recognises_jpg() {
+        assert!(is_image_path(&PathBuf::from("photo.jpg")));
+    }
+
+    /// Given: a path with a .svg extension
+    /// When: is_image_path is called
+    /// Then: returns false (SVG is text)
+    #[test]
+    fn is_image_path_excludes_svg() {
+        assert!(!is_image_path(&PathBuf::from("icon.svg")));
+    }
+
+    /// Given: a path with a .pdf extension
+    /// When: is_pdf_path is called
+    /// Then: returns true
+    #[test]
+    fn is_pdf_path_recognises_pdf() {
+        assert!(is_pdf_path(&PathBuf::from("doc.pdf")));
+    }
+
+    /// Given: a path with a .txt extension
+    /// When: is_pdf_path is called
+    /// Then: returns false
+    #[test]
+    fn is_pdf_path_rejects_txt() {
+        assert!(!is_pdf_path(&PathBuf::from("readme.txt")));
+    }
+
+    /// Given: a valid PDF header in a temp file
+    /// When: build_pdf_preview_lines is called
+    /// Then: lines mention "PDF" and do not contain "[binary file]"
+    #[test]
+    fn build_pdf_preview_lines_shows_pdf_format() {
+        let tmp = std::env::temp_dir().join(format!("trek_pdftest_{}", std::process::id()));
+        std::fs::write(&tmp, b"%PDF-1.4\n%%EOF\n").unwrap();
+        let lines = build_pdf_preview_lines(&tmp);
+        let joined = lines.join("\n");
+        assert!(joined.contains("PDF"), "expected PDF in: {joined}");
+        assert!(
+            !joined.contains("[binary file]"),
+            "unexpected binary placeholder: {joined}"
+        );
+        let _ = std::fs::remove_file(&tmp);
+    }
+
+    /// Given: a PNG file with a valid header
+    /// When: build_image_preview_lines is called
+    /// Then: lines mention "PNG" and do not contain "[binary file]"
+    #[test]
+    fn build_image_preview_lines_shows_png_format() {
+        let tmp = std::env::temp_dir().join(format!("trek_pngtest_{}", std::process::id()));
+        // Minimal PNG header (signature + partial IHDR — enough for imagesize)
+        let png_bytes: &[u8] = &[
+            0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x48,
+            0x44, 0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x02, 0x00, 0x00,
+            0x00, 0x90, 0x77, 0x53,
+        ];
+        // Write with .png extension so is_image_path works
+        let png_path = tmp.with_extension("png");
+        std::fs::write(&png_path, png_bytes).unwrap();
+        let lines = build_image_preview_lines(&png_path);
+        let joined = lines.join("\n");
+        assert!(joined.contains("PNG"), "expected PNG in: {joined}");
+        assert!(
+            !joined.contains("[binary file]"),
+            "unexpected binary placeholder: {joined}"
+        );
+        let _ = std::fs::remove_file(&png_path);
+    }
+
+    /// Given: a byte count in the GB range
+    /// When: human_bytes is called
+    /// Then: returns a GB-suffixed string
+    #[test]
+    fn human_bytes_gb() {
+        let s = human_bytes(2 * 1024 * 1024 * 1024);
+        assert!(s.ends_with(" GB"), "expected GB suffix, got: {s}");
+    }
+
+    /// Given: a byte count in the KB range
+    /// When: human_bytes is called
+    /// Then: returns a KB-suffixed string
+    #[test]
+    fn human_bytes_kb() {
+        let s = human_bytes(2048);
+        assert!(s.ends_with(" KB"), "expected KB suffix, got: {s}");
     }
 }

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -3569,3 +3569,97 @@ fn load_preview_replaces_old_rx_on_second_call() {
 
     let _ = std::fs::remove_dir_all(&tmp);
 }
+
+// ── Image / PDF preview tests ─────────────────────────────────────────────
+
+/// Given: a directory containing a 1×1 PNG file
+/// When: the PNG is selected and preview is loaded
+/// Then: preview lines contain format and dimension info (not "[binary file]")
+#[test]
+fn image_preview_shows_metadata_not_binary_placeholder() {
+    let tmp = std::env::temp_dir().join(format!("trek_img_{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&tmp);
+    // Minimal 1×1 red PNG (valid PNG signature + IHDR chunk)
+    let png_bytes: &[u8] = &[
+        0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, // PNG signature
+        0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52, // IHDR length + type
+        0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, // 1×1
+        0x08, 0x02, 0x00, 0x00, 0x00, 0x90, 0x77, 0x53, // 8-bit RGB + crc
+        0xde, 0x00, 0x00, 0x00, 0x0c, 0x49, 0x44, 0x41, // IDAT
+        0x54, 0x08, 0xd7, 0x63, 0xf8, 0xcf, 0xc0, 0x00, // compressed pixel
+        0x00, 0x00, 0x02, 0x00, 0x01, 0xe2, 0x21, 0xbc, // crc
+        0x33, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4e, // IEND
+        0x44, 0xae, 0x42, 0x60, 0x82, // IEND crc
+    ];
+    std::fs::write(tmp.join("photo.png"), png_bytes).unwrap();
+    let mut app = make_app_at(&tmp);
+    app.load_preview();
+    wait_for_preview(&mut app);
+
+    let all_lines = app.preview_lines.join("\n");
+    assert!(
+        !all_lines.contains("[binary file]"),
+        "image preview must not show [binary file] placeholder, got: {all_lines}"
+    );
+    assert!(
+        all_lines.to_lowercase().contains("png"),
+        "image preview should mention the format, got: {all_lines}"
+    );
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+/// Given: a directory containing a PDF file
+/// When: the PDF is selected and preview is loaded
+/// Then: preview lines contain useful info (not "[binary file]")
+#[test]
+fn pdf_preview_shows_info_not_binary_placeholder() {
+    let tmp = std::env::temp_dir().join(format!("trek_pdf_{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&tmp);
+    // Minimal valid-header PDF
+    let pdf_bytes = b"%PDF-1.4\n%%EOF\n";
+    std::fs::write(tmp.join("document.pdf"), pdf_bytes).unwrap();
+    let mut app = make_app_at(&tmp);
+    app.load_preview();
+    wait_for_preview(&mut app);
+
+    let all_lines = app.preview_lines.join("\n");
+    assert!(
+        !all_lines.contains("[binary file]"),
+        "pdf preview must not show [binary file] placeholder, got: {all_lines}"
+    );
+    assert!(
+        all_lines.to_lowercase().contains("pdf"),
+        "pdf preview should identify the file as PDF, got: {all_lines}"
+    );
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+/// Given: a directory containing a JPEG image
+/// When: the JPEG is selected and preview is loaded
+/// Then: preview lines do not show [binary file]
+#[test]
+fn jpeg_preview_shows_metadata() {
+    let tmp = std::env::temp_dir().join(format!("trek_jpg_{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&tmp);
+    // Minimal JPEG: SOI marker + APP0 JFIF header + EOI
+    let jpeg_bytes: &[u8] = &[
+        0xff, 0xd8, // SOI
+        0xff, 0xe0, 0x00, 0x10, // APP0 marker + length
+        0x4a, 0x46, 0x49, 0x46, 0x00, // "JFIF\0"
+        0x01, 0x01, // version 1.1
+        0x00, 0x00, 0x01, 0x00, 0x01, // aspect ratio 1:1
+        0x00, 0x00, // thumbnail 0x0
+        0xff, 0xd9, // EOI
+    ];
+    std::fs::write(tmp.join("photo.jpg"), jpeg_bytes).unwrap();
+    let mut app = make_app_at(&tmp);
+    app.load_preview();
+    wait_for_preview(&mut app);
+
+    let all_lines = app.preview_lines.join("\n");
+    assert!(
+        !all_lines.contains("[binary file]"),
+        "jpeg preview must not show [binary file], got: {all_lines}"
+    );
+    let _ = std::fs::remove_dir_all(&tmp);
+}


### PR DESCRIPTION
## Summary
- Raster images (`.png`, `.jpg`, `.gif`, `.bmp`, `.ico`, `.webp`, `.avif`, `.tiff`) now show format + pixel dimensions + file size instead of `[binary file]`
- PDFs now show format + PDF version + file size instead of `[binary file]`
- When `chafa` is installed: inline Unicode/sixel art rendered at 72 columns
- When `pdfinfo` is installed: full document metadata shown
- Both tools degrade gracefully when absent (install hint shown)
- SVG unchanged — it previews as text XML

## Test plan
- [x] `cargo test` — 321 tests pass, 0 failures
- [x] `cargo build --release` — clean release build
- [x] `cargo clippy -- -D warnings` — zero warnings
- [ ] Manual: navigate to a PNG/JPG/PDF and verify metadata card renders correctly

Closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)