### PR TITLE
feat(ops): background file operations with task manager (#104)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.59.0] - 2026-03-24
+
+### Added
+- **Background file operations with task manager** — copy, move, and archive extraction now run on background threads so Trek remains fully interactive during large transfers. A task manager panel (`Ctrl+T`, also accessible via the command palette) lists all active and recently completed operations with their status (⟳ running / ✓ done / ✗ failed), operation type, label, and elapsed time. Press `j`/`k` to navigate, `c` to clear completed tasks, and `Esc`/`q` to close. The panel is also shown in the preview pane area (replaces the preview while open). Status-bar messages now include a `(Ctrl+T to monitor)` hint when a background op is in flight.
+
+### Removed
+- The previously blocking synchronous `paste_clipboard` and `confirm_extract` methods have been replaced by their asynchronous equivalents and removed. All paste/extract actions are now non-blocking.
+
 ## [0.58.0] - 2026-03-24
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -781,7 +781,7 @@ dependencies = [
 
 [[package]]
 name = "trek"
-version = "0.58.0"
+version = "0.59.0"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trek"
-version = "0.58.0"
+version = "0.59.0"
 edition = "2021"
 rust-version = "1.80"
 description = "A terminal file manager with mouse-resizable panes"

--- a/src/app/file_ops.rs
+++ b/src/app/file_ops.rs
@@ -71,69 +71,6 @@ impl App {
         }
     }
 
-    /// Paste clipboard contents into the current directory.
-    ///
-    /// Conflicting names (already exist in cwd) are skipped with a warning.
-    pub fn paste_clipboard(&mut self) {
-        let Some(clip) = self.clipboard.take() else {
-            self.status_message = Some("Nothing in clipboard".to_string());
-            return;
-        };
-        let mut done = 0usize;
-        let mut skipped = 0usize;
-        let mut errors: Vec<String> = Vec::new();
-
-        for src in &clip.paths {
-            let file_name = match src.file_name() {
-                Some(n) => n,
-                None => continue,
-            };
-            let dst = self.cwd.join(file_name);
-
-            // Skip if destination already exists (conflict).
-            if dst.exists() && &dst != src {
-                skipped += 1;
-                continue;
-            }
-            // Skip trivial no-op (cut to same directory).
-            if clip.op == ClipboardOp::Cut && dst == *src {
-                continue;
-            }
-
-            let result = match clip.op {
-                ClipboardOp::Copy => ops::copy_path(src, &dst),
-                ClipboardOp::Cut => ops::move_path(src, &dst),
-            };
-            match result {
-                Ok(()) => done += 1,
-                Err(e) => errors.push(e.to_string()),
-            }
-        }
-
-        // For Cut, the clipboard is consumed. For Copy, keep it for repeated pastes.
-        if clip.op == ClipboardOp::Copy {
-            self.clipboard = Some(Clipboard {
-                op: ClipboardOp::Copy,
-                paths: clip.paths,
-            });
-        }
-
-        let verb = match clip.op {
-            ClipboardOp::Copy => "Copied",
-            ClipboardOp::Cut => "Moved",
-        };
-        let mut msg = format!("{} {} item{}", verb, done, if done == 1 { "" } else { "s" });
-        if skipped > 0 {
-            msg.push_str(&format!(" ({} skipped — already exists)", skipped));
-        }
-        if let Some(err) = errors.first() {
-            msg = format!("Error: {}", err);
-        }
-        self.status_message = Some(msg);
-        self.load_dir();
-        self.git_status = crate::git::GitStatus::load(&self.cwd);
-    }
-
     /// Begin a delete confirmation for the currently selected entry.
     pub fn begin_delete_current(&mut self) {
         if let Some(entry) = self.entries.get(self.selected) {
@@ -526,28 +463,6 @@ impl App {
                 self.pending_extract = Some(entry.path.clone());
             } else {
                 self.status_message = Some("Not an archive".to_string());
-            }
-        }
-    }
-
-    /// Run the extraction after the user confirms with y/Enter.
-    pub fn confirm_extract(&mut self) {
-        let path = match self.pending_extract.take() {
-            Some(p) => p,
-            None => return,
-        };
-        let name = path
-            .file_name()
-            .map(|n| n.to_string_lossy().into_owned())
-            .unwrap_or_else(|| path.to_string_lossy().into_owned());
-        match crate::archive::extract_archive(&path, &self.cwd) {
-            Ok(()) => {
-                self.status_message = Some(format!("Extracted: {}", name));
-                self.load_dir();
-                self.git_status = crate::git::GitStatus::load(&self.cwd);
-            }
-            Err(e) => {
-                self.status_message = Some(format!("Extract failed: {}", e));
             }
         }
     }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -30,6 +30,8 @@ mod quick_rename;
 mod search;
 mod selection;
 mod sort;
+pub mod task_manager;
+mod task_ops;
 mod yank;
 
 /// Maximum directory entries loaded in a single pane.
@@ -405,6 +407,14 @@ pub struct App {
     pub change_feed_mode: bool,
     /// Root directory being watched recursively. Used to compute relative paths.
     pub change_feed_root: PathBuf,
+
+    // --- Background file-operation task manager (Ctrl+T) ---
+    /// Tracks all background file operation tasks (copy, move, extract).
+    pub task_manager: task_manager::TaskManager,
+    /// True while the task manager overlay is visible.
+    pub task_manager_mode: bool,
+    /// In-flight background tasks awaiting results via their channels.
+    pub(super) task_pending: Vec<task_manager::PendingTask>,
 }
 
 #[derive(Clone)]
@@ -560,6 +570,9 @@ impl App {
             change_feed: change_feed::ChangeFeed::new(),
             change_feed_mode: false,
             change_feed_root: feed_root,
+            task_manager: task_manager::TaskManager::new(),
+            task_manager_mode: false,
+            task_pending: Vec::new(),
         };
         app.load_dir();
         Ok(app)

--- a/src/app/palette.rs
+++ b/src/app/palette.rs
@@ -64,6 +64,7 @@ pub enum ActionId {
     InspectClipboard,
     OpenFrecency,
     ToggleChangeFeed,
+    ToggleTaskManager,
     ShowHelp,
     OpenInCmuxTab,
     OpenToTheRight,
@@ -379,6 +380,11 @@ pub static PALETTE_ACTIONS: &[PaletteAction] = &[
         id: ActionId::OpenToTheRight,
         name: "Open file in new cmux pane to the right (double-click)",
         keys: "double-click",
+    },
+    PaletteAction {
+        id: ActionId::ToggleTaskManager,
+        name: "Toggle task manager (background file operations)",
+        keys: "Ctrl+T",
     },
     PaletteAction {
         id: ActionId::ShowHelp,

--- a/src/app/task_manager.rs
+++ b/src/app/task_manager.rs
@@ -1,0 +1,269 @@
+use std::collections::VecDeque;
+use std::sync::mpsc;
+use std::time::Instant;
+
+/// The kind of file operation a background task is performing.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum TaskKind {
+    Copy,
+    Move,
+    Extract,
+}
+
+impl TaskKind {
+    pub fn label(&self) -> &'static str {
+        match self {
+            TaskKind::Copy => "Copy",
+            TaskKind::Move => "Move",
+            TaskKind::Extract => "Extract",
+        }
+    }
+}
+
+/// The current status of a background file task.
+#[derive(Clone, Debug)]
+pub enum TaskStatus {
+    /// The operation is in progress on a background thread.
+    Running,
+    /// The operation completed successfully.
+    Done {
+        /// Human-readable summary, e.g. "Copied 3 files".
+        summary: String,
+    },
+    /// The operation failed.
+    Failed {
+        /// The first error message from the operation.
+        error: String,
+    },
+}
+
+/// A single background file operation tracked by the task manager.
+#[derive(Clone, Debug)]
+pub struct FileTask {
+    /// Unique monotonic ID assigned at creation.
+    pub id: u64,
+    pub kind: TaskKind,
+    /// Short display label, e.g. "config.toml" or "5 files → /tmp".
+    pub label: String,
+    pub status: TaskStatus,
+    pub started_at: Instant,
+}
+
+impl FileTask {
+    pub fn is_running(&self) -> bool {
+        matches!(self.status, TaskStatus::Running)
+    }
+}
+
+/// Result message sent from a background thread back to the main thread.
+pub struct TaskResult {
+    pub task_id: u64,
+    pub status: TaskStatus,
+    /// True when the task mutated the filesystem and the directory listing
+    /// should be refreshed.
+    pub refresh_dir: bool,
+}
+
+/// An in-flight background task: its ID and the receiver end of its channel.
+pub struct PendingTask {
+    pub rx: mpsc::Receiver<TaskResult>,
+}
+
+/// Manages background file tasks.
+///
+/// Holds the ordered list of tasks (most recent first) and tracks which row
+/// the user has highlighted in the overlay.
+pub struct TaskManager {
+    /// Tasks, most recent first.  Capped at MAX_TASKS.
+    pub tasks: VecDeque<FileTask>,
+    /// Index into `tasks` of the highlighted row (0 = most recent).
+    pub selected: usize,
+    next_id: u64,
+}
+
+/// Maximum number of tasks kept in the panel (oldest evicted when full).
+const MAX_TASKS: usize = 100;
+
+impl TaskManager {
+    pub fn new() -> Self {
+        Self {
+            tasks: VecDeque::new(),
+            selected: 0,
+            next_id: 1,
+        }
+    }
+
+    /// Register a new Running task and return its ID.
+    pub fn push(&mut self, kind: TaskKind, label: String) -> u64 {
+        let id = self.next_id;
+        self.next_id += 1;
+        self.tasks.push_front(FileTask {
+            id,
+            kind,
+            label,
+            status: TaskStatus::Running,
+            started_at: Instant::now(),
+        });
+        if self.tasks.len() > MAX_TASKS {
+            self.tasks.pop_back();
+        }
+        // Keep cursor in bounds.
+        self.selected = self.selected.min(self.tasks.len().saturating_sub(1));
+        id
+    }
+
+    /// Update the status of the task with `id`.
+    ///
+    /// No-op if the task is not found (already evicted).
+    pub fn update(&mut self, id: u64, status: TaskStatus) {
+        if let Some(task) = self.tasks.iter_mut().find(|t| t.id == id) {
+            task.status = status;
+        }
+    }
+
+    /// Move the highlight cursor up (toward more-recent tasks).
+    pub fn move_up(&mut self) {
+        self.selected = self.selected.saturating_sub(1);
+    }
+
+    /// Move the highlight cursor down (toward older tasks).
+    pub fn move_down(&mut self) {
+        if !self.tasks.is_empty() {
+            self.selected = (self.selected + 1).min(self.tasks.len() - 1);
+        }
+    }
+
+    /// Remove all completed tasks (Done and Failed).
+    pub fn clear_done(&mut self) {
+        self.tasks.retain(|t| t.is_running());
+        self.selected = self.selected.min(self.tasks.len().saturating_sub(1));
+    }
+
+    /// True when at least one task is currently running.
+    pub fn has_running(&self) -> bool {
+        self.tasks.iter().any(|t| t.is_running())
+    }
+}
+
+impl Default for TaskManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Given: an empty TaskManager
+    /// When: a task is pushed
+    /// Then: it appears at position 0 with Running status
+    #[test]
+    fn push_adds_task_at_front() {
+        let mut tm = TaskManager::new();
+        let id = tm.push(TaskKind::Copy, "file.txt".to_string());
+        assert_eq!(tm.tasks.len(), 1);
+        assert_eq!(tm.tasks[0].id, id);
+        assert!(tm.tasks[0].is_running());
+    }
+
+    /// Given: a running task
+    /// When: update is called with Done status
+    /// Then: the task's status becomes Done
+    #[test]
+    fn update_changes_task_status() {
+        let mut tm = TaskManager::new();
+        let id = tm.push(TaskKind::Move, "dir/".to_string());
+        tm.update(
+            id,
+            TaskStatus::Done {
+                summary: "Moved 1 item".to_string(),
+            },
+        );
+        assert!(!tm.tasks[0].is_running());
+    }
+
+    /// Given: two tasks (one running, one done)
+    /// When: clear_done is called
+    /// Then: only the running task remains
+    #[test]
+    fn clear_done_removes_completed_tasks() {
+        let mut tm = TaskManager::new();
+        let id1 = tm.push(TaskKind::Copy, "a.txt".to_string());
+        let id2 = tm.push(TaskKind::Move, "b.txt".to_string());
+        tm.update(
+            id1,
+            TaskStatus::Done {
+                summary: "ok".to_string(),
+            },
+        );
+        tm.clear_done();
+        assert_eq!(tm.tasks.len(), 1);
+        assert_eq!(tm.tasks[0].id, id2);
+    }
+
+    /// Given: a TaskManager with 3 tasks
+    /// When: move_down and move_up are called
+    /// Then: selected is clamped at boundaries
+    #[test]
+    fn move_cursor_clamps_at_boundaries() {
+        let mut tm = TaskManager::new();
+        tm.push(TaskKind::Copy, "a".to_string());
+        tm.push(TaskKind::Copy, "b".to_string());
+        tm.push(TaskKind::Copy, "c".to_string());
+        assert_eq!(tm.selected, 0);
+        tm.move_up(); // at top already
+        assert_eq!(tm.selected, 0);
+        tm.move_down();
+        assert_eq!(tm.selected, 1);
+        tm.move_down();
+        assert_eq!(tm.selected, 2);
+        tm.move_down(); // at bottom
+        assert_eq!(tm.selected, 2);
+    }
+
+    /// Given: a TaskManager with one running and one failed task
+    /// When: has_running is called
+    /// Then: returns true
+    #[test]
+    fn has_running_returns_true_when_any_task_is_running() {
+        let mut tm = TaskManager::new();
+        let id = tm.push(TaskKind::Extract, "archive.zip".to_string());
+        tm.push(TaskKind::Copy, "other.txt".to_string());
+        tm.update(
+            id,
+            TaskStatus::Failed {
+                error: "not found".to_string(),
+            },
+        );
+        assert!(tm.has_running());
+    }
+
+    /// Given: a TaskManager with only done/failed tasks
+    /// When: has_running is called
+    /// Then: returns false
+    #[test]
+    fn has_running_returns_false_when_no_task_is_running() {
+        let mut tm = TaskManager::new();
+        let id = tm.push(TaskKind::Copy, "f.txt".to_string());
+        tm.update(
+            id,
+            TaskStatus::Done {
+                summary: "ok".to_string(),
+            },
+        );
+        assert!(!tm.has_running());
+    }
+
+    /// Given: a TaskManager filled to MAX_TASKS
+    /// When: one more task is pushed
+    /// Then: the total count stays at MAX_TASKS (oldest evicted)
+    #[test]
+    fn push_evicts_oldest_when_full() {
+        let mut tm = TaskManager::new();
+        for i in 0..=MAX_TASKS {
+            tm.push(TaskKind::Copy, format!("file_{i}"));
+        }
+        assert_eq!(tm.tasks.len(), MAX_TASKS);
+    }
+}

--- a/src/app/task_ops.rs
+++ b/src/app/task_ops.rs
@@ -1,0 +1,225 @@
+use super::App;
+use crate::app::task_manager::{PendingTask, TaskKind, TaskResult, TaskStatus};
+use crate::ops::{self, ClipboardOp};
+use std::path::PathBuf;
+use std::sync::mpsc;
+
+impl App {
+    /// Toggle the task manager overlay open/closed.
+    pub fn toggle_task_manager(&mut self) {
+        self.task_manager_mode = !self.task_manager_mode;
+    }
+
+    /// Move the task manager cursor up.
+    pub fn task_manager_move_up(&mut self) {
+        self.task_manager.move_up();
+    }
+
+    /// Move the task manager cursor down.
+    pub fn task_manager_move_down(&mut self) {
+        self.task_manager.move_down();
+    }
+
+    /// Remove all completed tasks from the task manager.
+    pub fn task_manager_clear_done(&mut self) {
+        self.task_manager.clear_done();
+    }
+
+    /// Paste clipboard contents as a background task.
+    ///
+    /// Returns immediately — the actual copy/move runs on a background thread.
+    /// Directory listing is refreshed when the task completes (via `check_task_rx`).
+    pub fn paste_clipboard_async(&mut self) {
+        let Some(clip) = self.clipboard.take() else {
+            self.status_message = Some("Nothing in clipboard".to_string());
+            return;
+        };
+
+        let dest_dir = self.cwd.clone();
+        let op = clip.op;
+        let paths = clip.paths.clone();
+
+        // Collect (src, dst) pairs, checking for conflicts now (on the main thread).
+        let mut pairs: Vec<(PathBuf, PathBuf)> = Vec::new();
+        let mut skipped = 0usize;
+        for src in &paths {
+            let file_name = match src.file_name() {
+                Some(n) => n,
+                None => continue,
+            };
+            let dst = dest_dir.join(file_name);
+            if dst.exists() && &dst != src {
+                skipped += 1;
+                continue;
+            }
+            if op == ClipboardOp::Cut && dst == *src {
+                continue;
+            }
+            pairs.push((src.clone(), dst));
+        }
+
+        if pairs.is_empty() {
+            if skipped > 0 {
+                self.status_message =
+                    Some(format!("{} skipped — destination already exists", skipped));
+            } else {
+                self.status_message = Some("Nothing to paste".to_string());
+            }
+            // Restore the clipboard for copy operations.
+            if op == ClipboardOp::Copy {
+                self.clipboard = Some(crate::ops::Clipboard { op, paths });
+            }
+            return;
+        }
+
+        // Build a short label for the task panel.
+        let label = if pairs.len() == 1 {
+            let name = pairs[0]
+                .0
+                .file_name()
+                .map(|n| n.to_string_lossy().into_owned())
+                .unwrap_or_default();
+            format!("{} → {}", name, dest_dir.to_string_lossy())
+        } else {
+            format!("{} files → {}", pairs.len(), dest_dir.to_string_lossy())
+        };
+
+        let kind = match op {
+            ClipboardOp::Copy => TaskKind::Copy,
+            ClipboardOp::Cut => TaskKind::Move,
+        };
+        let task_id = self.task_manager.push(kind.clone(), label.clone());
+
+        let verb = match kind {
+            TaskKind::Copy => "Copying",
+            TaskKind::Move => "Moving",
+            _ => "Working on",
+        };
+        let short_label = if pairs.len() == 1 {
+            pairs[0]
+                .0
+                .file_name()
+                .map(|n| n.to_string_lossy().into_owned())
+                .unwrap_or_default()
+        } else {
+            format!("{} files", pairs.len())
+        };
+        self.status_message = Some(format!("{} {}… (Ctrl+T to monitor)", verb, short_label));
+
+        // For Copy: restore clipboard so repeated pastes work.
+        if op == ClipboardOp::Copy {
+            self.clipboard = Some(crate::ops::Clipboard { op, paths });
+        }
+
+        // Spawn background thread.
+        let (tx, rx) = mpsc::channel::<TaskResult>();
+        self.task_pending.push(PendingTask { rx });
+
+        std::thread::spawn(move || {
+            let mut done = 0usize;
+            let mut errors: Vec<String> = Vec::new();
+            for (src, dst) in &pairs {
+                let result = match op {
+                    ClipboardOp::Copy => ops::copy_path(src, dst),
+                    ClipboardOp::Cut => ops::move_path(src, dst),
+                };
+                match result {
+                    Ok(()) => done += 1,
+                    Err(e) => errors.push(e.to_string()),
+                }
+            }
+            let verb_past = match op {
+                ClipboardOp::Copy => "Copied",
+                ClipboardOp::Cut => "Moved",
+            };
+            let status = if let Some(err) = errors.first() {
+                TaskStatus::Failed { error: err.clone() }
+            } else {
+                TaskStatus::Done {
+                    summary: format!(
+                        "{} {} item{}{}",
+                        verb_past,
+                        done,
+                        if done == 1 { "" } else { "s" },
+                        if skipped > 0 {
+                            format!(" ({} skipped)", skipped)
+                        } else {
+                            String::new()
+                        }
+                    ),
+                }
+            };
+            let _ = tx.send(TaskResult {
+                task_id,
+                status,
+                refresh_dir: true,
+            });
+        });
+    }
+
+    /// Extract the currently pending archive as a background task.
+    pub fn confirm_extract_async(&mut self) {
+        let path = match self.pending_extract.take() {
+            Some(p) => p,
+            None => return,
+        };
+        let name = path
+            .file_name()
+            .map(|n| n.to_string_lossy().into_owned())
+            .unwrap_or_else(|| path.to_string_lossy().into_owned());
+        let dest_dir = self.cwd.clone();
+        let label = format!("{} → {}", name, dest_dir.to_string_lossy());
+
+        let task_id = self.task_manager.push(TaskKind::Extract, label);
+        self.status_message = Some(format!("Extracting {}… (Ctrl+T to monitor)", name));
+
+        let (tx, rx) = mpsc::channel::<TaskResult>();
+        self.task_pending.push(PendingTask { rx });
+
+        std::thread::spawn(move || {
+            let status = match crate::archive::extract_archive(&path, &dest_dir) {
+                Ok(()) => TaskStatus::Done {
+                    summary: format!("Extracted: {}", name),
+                },
+                Err(e) => TaskStatus::Failed {
+                    error: e.to_string(),
+                },
+            };
+            let _ = tx.send(TaskResult {
+                task_id,
+                status,
+                refresh_dir: true,
+            });
+        });
+    }
+
+    /// Poll all pending task receivers and apply any completed results.
+    ///
+    /// Must be called on every event-loop iteration.
+    pub fn check_task_rx(&mut self) {
+        let mut completed: Vec<(u64, TaskStatus, bool)> = Vec::new();
+        self.task_pending.retain(|pt| match pt.rx.try_recv() {
+            Ok(result) => {
+                completed.push((result.task_id, result.status, result.refresh_dir));
+                false
+            }
+            Err(mpsc::TryRecvError::Empty) => true,
+            Err(mpsc::TryRecvError::Disconnected) => false,
+        });
+
+        for (id, status, refresh) in completed {
+            // Update status message for the most-recently-completed task.
+            let summary = match &status {
+                TaskStatus::Done { summary } => summary.clone(),
+                TaskStatus::Failed { error } => format!("Error: {}", error),
+                TaskStatus::Running => unreachable!(),
+            };
+            self.status_message = Some(summary);
+            self.task_manager.update(id, status);
+            if refresh {
+                self.load_dir();
+                self.git_status = crate::git::GitStatus::load(&self.cwd);
+            }
+        }
+    }
+}

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -3663,3 +3663,118 @@ fn jpeg_preview_shows_metadata() {
     );
     let _ = std::fs::remove_dir_all(&tmp);
 }
+
+// ── Task manager tests ────────────────────────────────────────────────────
+
+/// Given: an app with a copied file on clipboard, pasted asynchronously
+/// When: paste_clipboard_async is called and the task completes
+/// Then: the destination file exists and status message reflects success
+#[test]
+fn paste_clipboard_async_copies_file_in_background() {
+    let tmp = std::env::temp_dir().join(format!("trek_paste_{}", std::process::id()));
+    let _ = std::fs::create_dir_all(&tmp);
+    let src_dir = tmp.join("src");
+    let dst_dir = tmp.join("dst");
+    let _ = std::fs::create_dir_all(&src_dir);
+    let _ = std::fs::create_dir_all(&dst_dir);
+    std::fs::write(src_dir.join("hello.txt"), b"hello").unwrap();
+
+    let mut app = make_app_at(&src_dir);
+    // Yank the file
+    app.clipboard_copy_current();
+    // Navigate to destination directory
+    app.cwd = dst_dir.clone();
+    app.load_dir();
+
+    app.paste_clipboard_async();
+
+    // The task should be running immediately after the call
+    assert!(
+        !app.task_pending.is_empty() || app.task_manager.tasks.len() > 0,
+        "task should be queued after paste_clipboard_async"
+    );
+
+    // Wait for the background task to complete (poll up to 1s)
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(1);
+    while !app.task_pending.is_empty() && std::time::Instant::now() < deadline {
+        app.check_task_rx();
+        std::thread::sleep(std::time::Duration::from_millis(10));
+    }
+
+    assert!(
+        dst_dir.join("hello.txt").exists(),
+        "destination file should exist after async copy completes"
+    );
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+/// Given: an app with task_manager_mode false
+/// When: toggle_task_manager is called
+/// Then: task_manager_mode becomes true
+#[test]
+fn toggle_task_manager_opens_panel() {
+    let dir = std::env::temp_dir();
+    let mut app = make_app_at(&dir);
+    assert!(!app.task_manager_mode);
+    app.toggle_task_manager();
+    assert!(app.task_manager_mode);
+    app.toggle_task_manager();
+    assert!(!app.task_manager_mode);
+}
+
+/// Given: an app with a completed (done) task in the task manager
+/// When: task_manager_clear_done is called
+/// Then: the completed task is removed from the list
+#[test]
+fn task_manager_clear_done_removes_completed_tasks() {
+    let dir = std::env::temp_dir();
+    let mut app = make_app_at(&dir);
+    use crate::app::task_manager::{TaskKind, TaskStatus};
+    let id = app
+        .task_manager
+        .push(TaskKind::Copy, "file.txt".to_string());
+    app.task_manager.update(
+        id,
+        TaskStatus::Done {
+            summary: "Copied 1 item".to_string(),
+        },
+    );
+    assert_eq!(app.task_manager.tasks.len(), 1);
+    app.task_manager_clear_done();
+    assert_eq!(app.task_manager.tasks.len(), 0);
+}
+
+/// Given: a task result sent via mpsc channel
+/// When: check_task_rx is called
+/// Then: the task status is updated and the channel is drained
+#[test]
+fn check_task_rx_delivers_result_and_drains_channel() {
+    let dir = std::env::temp_dir();
+    let mut app = make_app_at(&dir);
+    use crate::app::task_manager::{PendingTask, TaskKind, TaskResult, TaskStatus};
+    use std::sync::mpsc;
+
+    let task_id = app
+        .task_manager
+        .push(TaskKind::Copy, "file.txt".to_string());
+    let (tx, rx) = mpsc::channel::<TaskResult>();
+    app.task_pending.push(PendingTask { rx });
+
+    tx.send(TaskResult {
+        task_id,
+        status: TaskStatus::Done {
+            summary: "Copied 1 item".to_string(),
+        },
+        refresh_dir: false,
+    })
+    .unwrap();
+
+    app.check_task_rx();
+
+    assert!(app.task_pending.is_empty(), "channel should be drained");
+    let task = app.task_manager.tasks.front().unwrap();
+    assert!(
+        matches!(task.status, TaskStatus::Done { .. }),
+        "task status should be Done"
+    );
+}

--- a/src/events.rs
+++ b/src/events.rs
@@ -53,16 +53,19 @@ pub fn run(
     }
 
     loop {
-        // Deliver any completed async preview before drawing so the freshest
-        // data is always rendered on this frame.
+        // Deliver any completed async preview and background file-op results
+        // before drawing so the freshest data is always rendered on this frame.
         app.check_preview_rx();
+        app.check_task_rx();
 
         terminal.draw(|f| crate::ui::draw(f, &mut app))?;
 
         // Use a short poll timeout whenever background work is in flight so
         // the loop can process watcher events and preview results promptly.
-        let has_background_work =
-            app.watcher.is_some() || app.recursive_watcher.is_some() || app.preview_rx.is_some();
+        let has_background_work = app.watcher.is_some()
+            || app.recursive_watcher.is_some()
+            || app.preview_rx.is_some()
+            || !app.task_pending.is_empty();
         let maybe_event = if has_background_work {
             if event::poll(Duration::from_millis(150))? {
                 Some(event::read()?)
@@ -84,6 +87,14 @@ pub fn run(
                 if app.show_help {
                     // Any key closes help overlay.
                     app.show_help = false;
+                } else if app.task_manager_mode {
+                    match key.code {
+                        KeyCode::Esc | KeyCode::Char('q') => app.toggle_task_manager(),
+                        KeyCode::Char('j') | KeyCode::Down => app.task_manager_move_down(),
+                        KeyCode::Char('k') | KeyCode::Up => app.task_manager_move_up(),
+                        KeyCode::Char('c') => app.task_manager_clear_done(),
+                        _ => {}
+                    }
                 } else if !app.pending_delete.is_empty() {
                     // t/y → trash (recoverable); D → permanent delete; anything else → cancel.
                     match key.code {
@@ -96,7 +107,7 @@ pub fn run(
                 } else if app.pending_extract.is_some() {
                     match key.code {
                         KeyCode::Char('y') | KeyCode::Char('Y') | KeyCode::Enter => {
-                            app.confirm_extract()
+                            app.confirm_extract_async()
                         }
                         _ => app.cancel_extract(),
                     }
@@ -258,7 +269,7 @@ pub fn run(
                         }
                         KeyCode::Char('p') => {
                             app.close_clipboard_inspect();
-                            app.paste_clipboard();
+                            app.paste_clipboard_async();
                         }
                         _ => {}
                     }
@@ -331,6 +342,9 @@ pub fn run(
                         KeyCode::Char('a') => app.toggle_hex_view(),
                         KeyCode::Char('w') => app.toggle_preview_pane(),
                         KeyCode::Char('T') => app.toggle_timestamps(),
+                        KeyCode::Char('t') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                            app.toggle_task_manager()
+                        }
                         KeyCode::Char('U') => app.toggle_preview_wrap(),
                         KeyCode::Char('N') => app.toggle_dir_counts(),
                         KeyCode::Char('F') => app.toggle_change_feed(),
@@ -354,7 +368,7 @@ pub fn run(
                         KeyCode::Char('C') => app.clipboard_copy_selected(),
                         KeyCode::Char('x') => app.clipboard_cut_current(),
                         KeyCode::Char('p') if !key.modifiers.contains(KeyModifiers::CONTROL) => {
-                            app.paste_clipboard()
+                            app.paste_clipboard_async()
                         }
                         KeyCode::Delete => app.begin_delete_current(),
                         KeyCode::Char('X') => app.begin_delete_selected(),
@@ -537,7 +551,7 @@ fn execute_palette_action(
         ActionId::ClipboardCopyCurrent => app.clipboard_copy_current(),
         ActionId::ClipboardCopySelected => app.clipboard_copy_selected(),
         ActionId::ClipboardCutCurrent => app.clipboard_cut_current(),
-        ActionId::PasteClipboard => app.paste_clipboard(),
+        ActionId::PasteClipboard => app.paste_clipboard_async(),
         ActionId::BeginDeleteCurrent => app.begin_delete_current(),
         ActionId::BeginDeleteSelected => app.begin_delete_selected(),
         ActionId::BeginMkdir => app.begin_mkdir(),
@@ -570,6 +584,7 @@ fn execute_palette_action(
         ActionId::InspectClipboard => app.open_clipboard_inspect(),
         ActionId::OpenFrecency => app.open_frecency(),
         ActionId::ToggleChangeFeed => app.toggle_change_feed(),
+        ActionId::ToggleTaskManager => app.toggle_task_manager(),
         ActionId::OpenInCmuxTab => app.open_in_cmux_tab(),
         ActionId::OpenToTheRight => app.open_to_the_right(),
         ActionId::ShowHelp => app.show_help = true,

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -86,6 +86,8 @@ pub fn draw(f: &mut Frame, app: &mut App) {
     if !app.preview_collapsed {
         if app.change_feed_mode {
             draw_change_feed_pane(f, app, pane_chunks[2]);
+        } else if app.task_manager_mode {
+            draw_task_manager_pane(f, app, pane_chunks[2]);
         } else {
             draw_preview_pane(f, app, pane_chunks[2]);
         }
@@ -2148,5 +2150,157 @@ mod tests {
         let result = truncate_with_ellipsis("café world", 5);
         assert!(result.chars().count() <= 5);
         assert!(result.ends_with('…'));
+    }
+}
+
+/// Render the background task manager panel in the preview pane area.
+///
+/// Shows all recent file operations (copy, move, extract) with their status.
+/// Active operations show a spinner-style indicator; completed ones show a
+/// summary or error. Press `c` to clear completed tasks, `j`/`k` to navigate,
+/// `Esc`/`q` to close.
+fn draw_task_manager_pane(f: &mut Frame, app: &App, area: Rect) {
+    use crate::app::task_manager::TaskStatus;
+
+    let has_running = app.task_manager.has_running();
+    let title = if has_running {
+        " Task Manager [running] "
+    } else {
+        " Task Manager "
+    };
+
+    let block = Block::default()
+        .title(title)
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Yellow));
+
+    let inner = block.inner(area);
+    f.render_widget(block, area);
+
+    if app.task_manager.tasks.is_empty() {
+        let msg = Paragraph::new(Line::from(Span::styled(
+            "No background tasks",
+            Style::default().fg(Color::DarkGray),
+        )))
+        .alignment(ratatui::layout::Alignment::Center);
+        f.render_widget(msg, inner);
+
+        // Footer hint
+        let hint = Paragraph::new(Line::from(Span::styled(
+            "  Ctrl+T or q to close",
+            Style::default().fg(Color::DarkGray),
+        )));
+        if inner.height >= 3 {
+            let hint_area = Rect {
+                y: inner.y + inner.height - 1,
+                height: 1,
+                ..inner
+            };
+            f.render_widget(hint, hint_area);
+        }
+        return;
+    }
+
+    let height = inner.height as usize;
+    let total = app.task_manager.tasks.len();
+    let selected = app.task_manager.selected;
+
+    let scroll_offset = if selected < height {
+        0
+    } else {
+        selected - height + 1
+    };
+
+    let mut rows: Vec<Line> = Vec::with_capacity(height);
+    for (i, task) in app
+        .task_manager
+        .tasks
+        .iter()
+        .enumerate()
+        .skip(scroll_offset)
+        .take(height.saturating_sub(1))
+    {
+        let is_selected = i == selected;
+
+        let (status_sym, status_style) = match &task.status {
+            TaskStatus::Running => ("⟳", Style::default().fg(Color::Cyan)),
+            TaskStatus::Done { .. } => ("✓", Style::default().fg(Color::Green)),
+            TaskStatus::Failed { .. } => ("✗", Style::default().fg(Color::Red)),
+        };
+
+        let kind_label = task.kind.label();
+
+        let detail = match &task.status {
+            TaskStatus::Running => task.label.clone(),
+            TaskStatus::Done { summary } => summary.clone(),
+            TaskStatus::Failed { error } => format!("Error: {}", error),
+        };
+
+        let elapsed = {
+            let secs = task.started_at.elapsed().as_secs();
+            if secs < 60 {
+                format!("{}s", secs)
+            } else {
+                format!("{}m{}s", secs / 60, secs % 60)
+            }
+        };
+
+        let row_style = if is_selected {
+            Style::default().bg(Color::DarkGray)
+        } else {
+            Style::default()
+        };
+
+        let width = inner.width as usize;
+        let prefix = format!("  {} {:8}  ", status_sym, kind_label);
+        let suffix = format!("  {}", elapsed);
+        let available = width.saturating_sub(prefix.len() + suffix.len());
+        let detail_trunc = truncate_with_ellipsis(&detail, available);
+
+        let line = Line::from(vec![
+            Span::styled("  ", row_style),
+            Span::styled(status_sym.to_string(), status_style.patch(row_style)),
+            Span::styled(format!(" {:8}  ", kind_label), row_style),
+            Span::styled(detail_trunc, row_style),
+            Span::styled(
+                format!("  {}", elapsed),
+                Style::default().fg(Color::DarkGray).patch(row_style),
+            ),
+        ]);
+        rows.push(line);
+    }
+
+    // Footer: scroll indicator + keybinding hints.
+    let footer_text = if total > height.saturating_sub(1) {
+        format!(
+            "  {}/{} tasks  │  j/k navigate  c clear done  q close",
+            selected + 1,
+            total
+        )
+    } else {
+        "  j/k navigate  c clear done  q close".to_string()
+    };
+    let footer = Line::from(Span::styled(
+        footer_text,
+        Style::default().fg(Color::DarkGray),
+    ));
+
+    let content_height = inner.height.saturating_sub(1) as usize;
+    for (row_idx, line) in rows.into_iter().take(content_height).enumerate() {
+        let row_area = Rect {
+            y: inner.y + row_idx as u16,
+            height: 1,
+            ..inner
+        };
+        f.render_widget(Paragraph::new(line), row_area);
+    }
+
+    if inner.height >= 2 {
+        let footer_area = Rect {
+            y: inner.y + inner.height - 1,
+            height: 1,
+            ..inner
+        };
+        f.render_widget(Paragraph::new(footer), footer_area);
     }
 }


### PR DESCRIPTION
## Summary
- Copy, move, and archive extraction now run on background threads — Trek stays interactive during large transfers
- Task manager panel (`Ctrl+T` or command palette) shows all active and recent ops with ⟳/✓/✗ status, kind, label, and elapsed time
- `j`/`k` navigates, `c` clears completed, `Esc`/`q` closes the panel
- Status bar shows `(Ctrl+T to monitor)` hint when an op is in flight
- Removed blocking `paste_clipboard` and `confirm_extract` — fully superseded by async versions

## Test plan
- [x] `cargo test` — 332 tests pass, 0 failures
- [x] `cargo build --release` — clean release build
- [x] `cargo clippy -- -D warnings` — zero warnings
- [ ] Manual: copy a large directory, navigate freely while it copies; verify task manager shows progress

Closes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)