### PR TITLE
Sync documentation with v0.62.1 implementation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -25,11 +25,11 @@ When you open a file, Trek routes it to the appropriate tool — your editor for
 - **Watch mode** — the file tree refreshes automatically when the filesystem changes; see what the AI created in real time
 - **Git status overlays** — modified, staged, untracked, and deleted files are marked inline in the tree as the AI works
 - **File preview** — inspect what was written without opening an editor; the right pane updates as you navigate
-- **Content search** — ripgrep-powered full-text search across the project
-- **Fuzzy file search** — locate any file instantly with `/` or `Ctrl+F`
+- **Content search** — ripgrep-powered full-text search across the project (`Ctrl+F`)
+- **Fuzzy file search** — locate any file in the current directory instantly (`/`)
 - **Mouse-resizable panes** — drag dividers to reconfigure the layout; mouse and keyboard are both first-class
 - **Archive browsing** — navigate into `.zip`, `.tar.gz`, and other archives as virtual directories
-- **Command palette** — press `?` to see every available action with its keybinding, searchable by name
+- **Command palette** — press `:` to see every available action with its keybinding, searchable by name
 - **Shell integration** — the `m` function launches Trek and `cd`s your shell to the directory you exit from
 
 ---

--- a/docs/reference/command-palette.md
+++ b/docs/reference/command-palette.md
@@ -1,6 +1,6 @@
 # Command Palette
 
-Trek v0.53.0
+Trek v0.62.1
 
 The command palette is Trek's primary discoverability surface. It lists every
 action available in the current context, lets you filter by name, and executes

--- a/docs/reference/keybindings.md
+++ b/docs/reference/keybindings.md
@@ -1,6 +1,6 @@
 # Keybinding Reference
 
-Trek v0.55.0
+Trek v0.62.1
 
 This page lists every keybinding available in Trek, organized by category.
 If you can't find what you need here, press `:` to open the command palette and
@@ -40,9 +40,9 @@ Pressing `l`, `→`, or `Enter` on a **file** opens it in a new cmux surface. Tr
 
 | File type | Opens with |
 |-----------|-----------|
-| HTML (`.html`, `.htm`) | System default opener (`open` / `xdg-open`) |
-| Images (`.png`, `.jpg`, `.gif`, etc.) | System default opener |
-| PDFs (`.pdf`) | System default opener |
+| HTML (`.html`, `.htm`) | cmux embedded browser (`cmux browser open`) |
+| Images (`.png`, `.jpg`, `.gif`, etc.) | System default opener (`open` / `xdg-open`) |
+| PDFs (`.pdf`) | System default opener (`open` / `xdg-open`) |
 | All other text / code files | `$EDITOR` in a new terminal surface |
 
 **Mouse actions also trigger cmux routing:**
@@ -69,13 +69,15 @@ To copy a file path without opening the file, use `y` (relative path) or `Y` (ab
 | `n` / `F2` | Quick rename current entry |
 | `W` | Duplicate current entry in place |
 | `L` | Create symlink to current entry |
+| `P` | Edit file permissions (chmod) |
 | `c` | Copy to clipboard |
 | `C` | Copy all selected entries to clipboard |
 | `x` | Cut to clipboard |
 | `X` | Cut all selected entries to clipboard |
 | `p` | Paste from clipboard |
-| `F` | Open clipboard inspector |
-| `d` | Delete / trash current entry |
+| `F9` | Open clipboard inspector |
+| `Delete` | Trash current entry (requires confirmation) |
+| `u` | Undo last trash operation |
 
 ---
 
@@ -86,6 +88,8 @@ To copy a file path without opening the file, use `y` (relative path) or `Y` (ab
 | `Space` | Toggle selection on current entry |
 | `J` | Select current entry and move down (range select) |
 | `K` | Select current entry and move up (range select) |
+| `v` | Select all files in the current directory |
+| `Esc` | Clear all selections (when no search filter is active) |
 
 Selected entries are highlighted in the file listing and used by bulk
 operations such as `C` and `X`.
@@ -107,6 +111,8 @@ key again to return to the default file content preview.
 | `f` | Compare two selected files (select exactly 2 first) |
 | `#` | Toggle line numbers in preview pane |
 | `U` | Toggle word wrap in preview pane |
+
+> **Note:** Hash preview (`H`) is not yet available.
 
 ---
 
@@ -162,7 +168,7 @@ Trek has two bookmark mechanisms:
 | `` ` `` + letter | Set session mark at current directory |
 | `'` + letter | Jump to session mark |
 
-Any letter `a`–`z` is a valid mark or bookmark slot.
+Any letter `a`–`z` or `A`–`Z` is a valid mark or bookmark slot (52 total slots).
 
 ---
 
@@ -179,6 +185,17 @@ Any letter `a`–`z` is a valid mark or bookmark slot.
 
 Fuzzy search matches against file names in the current directory tree.
 Content search (`Ctrl+F`) uses ripgrep and respects `.gitignore` by default.
+
+---
+
+## Session and Monitoring
+
+| Key | Action |
+|-----|--------|
+| `F` | Toggle live change feed |
+| `Ctrl+S` | Open session change summary |
+| `Ctrl+T` | Open task manager (background copy / move / extract) |
+| `R` | Refresh git status |
 
 ---
 

--- a/docs/usage/file-operations.md
+++ b/docs/usage/file-operations.md
@@ -10,7 +10,7 @@ Trek handles the full range of day-to-day file management tasks: creating, copyi
 |-------|--------|
 | `l` / `→` / `Enter` | Enter a directory; for files, open in a new cmux tab (routes by file type — see below) |
 | Right-click | Select the file and open it in a new cmux tab (same routing as `l` / `Enter`) |
-| Double-click | Open the file in a new cmux pane split to the right (`cmux new-pane --direction right`); falls back to system opener for images, HTML, and PDFs |
+| Double-click | Open the file in a new cmux pane split to the right (`cmux new-pane --direction right`); falls back to system opener for images and PDFs |
 | `o` | Open in terminal editor — checks `$VISUAL`, then `$EDITOR`, then falls back to `vi` |
 | `O` | Open with system default — `open` on macOS, `xdg-open` on Linux |
 
@@ -20,9 +20,9 @@ When you press `l`, `→`, or `Enter` on a file, right-click a file, or double-c
 
 | File type | `l` / `Enter` / right-click opens with | Double-click opens with |
 |-----------|----------------------------------------|------------------------|
-| HTML (`.html`, `.htm`) | System default opener (`open` / `xdg-open`) | System default opener |
-| Images (`.png`, `.jpg`, `.gif`, etc.) | System default opener | System default opener |
-| PDFs (`.pdf`) | System default opener | System default opener |
+| HTML (`.html`, `.htm`) | cmux embedded browser (`cmux browser open`) | cmux embedded browser |
+| Images (`.png`, `.jpg`, `.gif`, etc.) | System default opener (`open` / `xdg-open`) | System default opener |
+| PDFs (`.pdf`) | System default opener (`open` / `xdg-open`) | System default opener |
 | All other text / code files | `$EDITOR` in a new cmux tab | `$EDITOR` in a new cmux pane split right |
 
 This requires Trek to be running inside cmux. When Trek is not running inside cmux, all three open methods show a hint in the status bar instead. Use `o` or `O` as alternatives in that case.
@@ -53,7 +53,7 @@ Trek uses a clipboard model: copy or cut entries first, then paste them into the
 | `x` | Cut the current entry |
 | `X` | Cut all selected entries |
 | `p` | Paste clipboard contents into the current directory |
-| `F` | Open the clipboard inspector — shows queued items color-coded by operation (green = copy, yellow = cut); press `p` inside to paste, `Esc` to close |
+| `F9` | Open the clipboard inspector — shows queued items color-coded by operation (green = copy, yellow = cut); press `p` inside to paste, `Esc` to close |
 
 ---
 
@@ -61,9 +61,10 @@ Trek uses a clipboard model: copy or cut entries first, then paste them into the
 
 | Key | Action |
 |-----|--------|
-| `d` | Delete or trash the current entry — requires confirmation |
+| `Delete` | Trash the current entry — requires confirmation |
+| `u` | Undo the last trash operation |
 
-Bulk deletion uses `X` (cut all selected entries) combined with a delete confirmation, or select entries first and then use `d`.
+Bulk deletion: select entries first (see Selection below), then press `Delete` or `X` to trash them all.
 
 ---
 
@@ -72,6 +73,7 @@ Bulk deletion uses `X` (cut all selected entries) combined with a delete confirm
 | Key | Action |
 |-----|--------|
 | `n` / `F2` | Quick rename — opens an inline input bar pre-filled with the current name |
+| `P` | Edit file permissions — opens an octal chmod input bar |
 
 ---
 
@@ -84,6 +86,8 @@ Build a selection set before running bulk operations like copy or cut.
 | `Space` | Toggle selection on the current entry |
 | `J` (Shift+J) | Select current entry and move cursor down (range select) |
 | `K` (Shift+K) | Select current entry and move cursor up (range select) |
+| `v` | Select all files in the current directory |
+| `Esc` | Clear all selections (when no search filter is active) |
 
 ---
 

--- a/docs/usage/git.md
+++ b/docs/usage/git.md
@@ -8,12 +8,13 @@ Trek surfaces git information inline in the file listing and preview pane. It do
 
 When Trek detects a git repository, each entry in the listing shows a colored status indicator alongside its name:
 
-| Indicator | Meaning |
-|-----------|---------|
-| `M` | Modified — tracked file with unstaged changes |
-| `S` | Staged — changes added to the index |
-| `??` | Untracked — new file not yet known to git |
-| `D` | Deleted — tracked file removed from disk |
+| Indicator | Color | Meaning |
+|-----------|-------|---------|
+| `●` | Yellow | Modified — tracked file with unstaged changes |
+| `✚` | Green | Staged — changes added to the index (also shown for files with both staged and unstaged changes) |
+| `+` | Cyan | Untracked — new file not yet known to git |
+| `✖` | Red | Deleted — tracked file removed from disk |
+| `✖` | Red | Conflict — file in an unmerged state |
 
 The path bar also shows the current branch name so you always know which branch you are on.
 

--- a/docs/usage/navigation.md
+++ b/docs/usage/navigation.md
@@ -85,8 +85,8 @@ Trek supports mouse input throughout. In addition to clicking to select entries 
 
 | Action | Effect |
 |--------|--------|
-| Right-click | Selects the entry and opens it in a new cmux tab — the same routing used by `l` / `Enter` (code and text in `$EDITOR`; images, HTML, and PDFs via the system opener) |
-| Double-click | Opens the file in a new cmux pane split to the right (`cmux new-pane --direction right`); falls back to the system opener for images, HTML, and PDFs |
+| Right-click | Selects the entry and opens it in a new cmux tab — the same routing used by `l` / `Enter` (HTML in the cmux browser; images and PDFs via the system opener; code and text in `$EDITOR`) |
+| Double-click | Opens the file in a new cmux pane split to the right (`cmux new-pane --direction right`); falls back to the system opener for images and PDFs |
 
 When Trek is not running inside cmux, both actions show a hint in the status bar instead of launching an external surface. Use `o` or `O` as keyboard alternatives in that case.
 

--- a/docs/usage/preview.md
+++ b/docs/usage/preview.md
@@ -20,7 +20,6 @@ Preview modes are toggled by key and are mutually exclusive with each other. Pre
 |-----|------|-------------|
 | `d` | Diff preview | Shows `git diff HEAD -- <file>` for the selected file |
 | `m` | Meta card | Shows file metadata: permissions, size, and timestamps. For text files also shows line, word, and character counts. For symlinks shows the target path and whether it resolves. |
-| `H` | Hash preview | Shows the SHA-256 checksum using `shasum -a 256` or `sha256sum`. Files larger than 512 MB show a size-limit message instead. |
 | `V` | Git log preview | Shows `git log --oneline -30 -- <path>`. Works for directories as well as files — directories show commits that touched any file in the subtree. |
 | `a` | Hex dump | Shows a hex dump via `xxd`, falling back to `hexdump -C` if `xxd` is not available. Files larger than 4 MB show a size-limit message. |
 | `D` | Disk usage | For directories: shows immediate children sorted largest-first with Unicode block bars representing relative size. Pressing `D` on a file shows an error. |
@@ -59,7 +58,6 @@ The preview pane title bar shows a badge identifying the active mode or display 
 |-------|---------|
 | `[diff]` | Git diff mode active |
 | `[meta]` | Metadata view active |
-| `[hash]` | Hash view active |
 | `[log]` | Git log mode active |
 | `[hex]` | Hex dump mode active |
 | `[du]` | Disk usage mode active |

--- a/docs/usage/watch-mode.md
+++ b/docs/usage/watch-mode.md
@@ -13,7 +13,7 @@ Press `I` (uppercase) to disable watch mode. Press `I` again to re-enable it.
 | Enabled (default) | `"Watch mode ON — listing auto-refreshes on changes"` |
 | Disabled | `"Watch mode OFF"` |
 
-When watch mode is active, a cyan `[watch]` badge appears in the path bar. When you disable it, the badge disappears and the listing no longer auto-refreshes — use `R` to refresh manually.
+When watch mode is active, a cyan `[watch]` badge appears in the path bar. When you disable it, the badge disappears and the listing no longer auto-refreshes. Use `R` to refresh the git status overlay at any time.
 
 ---
 


### PR DESCRIPTION
## Summary

Audited the documentation against the actual v0.62.1 source and corrected a broad set of drift across the reference and usage guides:

- **Version numbers** — `keybindings.md` (v0.55.0) and `command-palette.md` (v0.53.0) were stale; both bumped to v0.62.1
- **Wrong key bindings** — `d` was documented as "delete" in multiple places; it is actually "toggle diff preview" (`Delete` is the trash key). `F` was documented as "clipboard inspector"; it is the live change feed (`F9` is the clipboard inspector)
- **Missing keys** — added `v` (select all), `Esc` (clear selections), `P` (chmod), `u` (undo trash), `F9` (clipboard inspector), and a new "Session and Monitoring" section covering `F`, `Ctrl+S`, `Ctrl+T`, `R`
- **Unimplemented feature** — removed `H` hash preview from `keybindings.md` and `preview.md`; the mode is referenced in source comments but the field and key handler do not exist
- **HTML default routing** — multiple pages said HTML opens with the system default opener; the actual default rule is `cmux browser open` (cmux embedded browser)
- **Git status indicators** — `git.md` documented text codes (`M`, `S`, `??`, `D`) but the renderer emits Unicode symbols (`●`/`✚`/`+`/`✖`); updated table and added the Conflict state
- **`R` key** — `watch-mode.md` claimed `R` does a manual directory refresh; it refreshes git status only
- **`docs/index.md`** — command palette key listed as `?` (that's the help overlay); corrected to `:`; also clarified `/` vs `Ctrl+F` search descriptions
- **Bookmark slots** — noted that `A`–`Z` are valid in addition to `a`–`z` (52 total slots)

## Test plan

- [ ] Review the diff for correctness against the source
- [ ] Confirm the docs site renders the updated pages as expected

https://claude.ai/code/session_01Y856C7sZhXCYt1ADYWRWJs